### PR TITLE
[Feat] 공통 dto 및 예외 처리 로직 추가

### DIFF
--- a/src/main/java/com/fondant/global/dto/ResponseDto.java
+++ b/src/main/java/com/fondant/global/dto/ResponseDto.java
@@ -3,7 +3,7 @@ package com.fondant.global.dto;
 public record ResponseDto<D>(
         String code,
         String message,
-        D data
+        D response
 ) {
     private static final String SUCCESS_CODE = "SUCCESS";
 

--- a/src/main/java/com/fondant/global/dto/ResponseDto.java
+++ b/src/main/java/com/fondant/global/dto/ResponseDto.java
@@ -1,0 +1,21 @@
+package com.fondant.global.dto;
+
+public record ResponseDto<D>(
+        String code,
+        String message,
+        D data
+) {
+    private static final String SUCCESS_CODE = "SUCCESS";
+
+    public static <D> ResponseDto<D> ofSuccess(SuccessMessage success, D data) {
+        return new ResponseDto<>(SUCCESS_CODE, success.getMessage(), data);
+    }
+
+    public static ResponseDto<Void> ofSuccess(SuccessMessage success) {
+        return new ResponseDto<>(SUCCESS_CODE, success.getMessage(), null);
+    }
+
+    public static ResponseDto<Void> ofFailure(String errorCode, String message) {
+        return new ResponseDto<>(errorCode, message, null);
+    }
+}

--- a/src/main/java/com/fondant/global/dto/SuccessMessage.java
+++ b/src/main/java/com/fondant/global/dto/SuccessMessage.java
@@ -1,0 +1,19 @@
+package com.fondant.global.dto;
+
+public enum SuccessMessage {
+    OPERATION_SUCCESS("요청이 성공적으로 처리되었습니다."),
+    CREATE_SUCCESS("등록이 완료되었습니다."),
+    UPDATE_SUCCESS("수정이 완료되었습니다."),
+    DELETE_SUCCESS("삭제가 완료되었습니다.");
+
+
+    private final String message;
+
+    SuccessMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/fondant/global/exception/ApiException.java
+++ b/src/main/java/com/fondant/global/exception/ApiException.java
@@ -1,0 +1,15 @@
+package com.fondant.global.exception;
+
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ApiException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/fondant/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/fondant/global/exception/ApiExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.fondant.global.exception;
+
+import com.fondant.global.dto.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ResponseDto<Void>> handleApiException(ApiException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ResponseDto.ofFailure(errorCode.getErrorCode(),errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseDto<Void>> handleGeneralException(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDto.ofFailure("INTERNAL_SERVER_ERROR", "An unexpected error occurred"));
+    }
+}

--- a/src/main/java/com/fondant/global/exception/ErrorCode.java
+++ b/src/main/java/com/fondant/global/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.fondant.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getMessage();
+    String getErrorCode();
+}

--- a/src/main/java/com/fondant/test/TestController.java
+++ b/src/main/java/com/fondant/test/TestController.java
@@ -1,0 +1,20 @@
+package com.fondant.test;
+
+import com.fondant.global.dto.ResponseDto;
+import com.fondant.global.dto.SuccessMessage;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/test")
+public class TestController {
+
+    @GetMapping("/success")
+    public ResponseEntity<ResponseDto<TestDto>> successTest(){
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                TestDto.of("강지원",25)));
+    }
+}

--- a/src/main/java/com/fondant/test/TestController.java
+++ b/src/main/java/com/fondant/test/TestController.java
@@ -5,7 +5,6 @@ import com.fondant.global.dto.SuccessMessage;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/com/fondant/test/TestDto.java
+++ b/src/main/java/com/fondant/test/TestDto.java
@@ -1,0 +1,13 @@
+package com.fondant.test;
+
+import lombok.Builder;
+
+@Builder
+public record TestDto(
+        String name,
+        int age
+) {
+    public static TestDto of(String name, int age) {
+        return TestDto.builder().name(name).age(age).build();
+    }
+}


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #5 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
본격적으로 로직 구현하기 전에 공통 dto가 필요할 것 같아 추가해 두었습니다.

### global DTO
API 명세서와 비교해 변경된 사항을 안내드립니다.

- `status`→ `code`
  ResponseEntity에 이미 HTTP 상태 코드가 포함되어 있고, HTTP 상태만으로 모든 상황을 표현하기 어려운 경우가 있어, custom code를 사용하는 방식으로 변경하였습니다.
- `response` → `data`
  반환되는 데이터를 더 명확히 표현하기 위해 이름을 data로 변경하였습니다.

```json
  {
     "code" : "SUCCESS"
     "message" : "정보가 조회되었습니다."
     "data" : {
           "name": "강지원",
           "age": 25
    }
}
```

### custom 예외처리 
사용법에 대해서는 추후에 작성해서 올려놓겠습니다.

예외가 발생하면 다음과 같이 반환됩니다.
```json
  {
     "code" : "U1" /*에러코드도 커스텀화*/
     "message" : "인가되지 않은 사용자 입니다."
     "data" : null
}
```


## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
더 자세한 사항은 리뷰로 간단히 남겨놓겠습니다 ! 
