### PR TITLE
[Feat] 상품 상세 조회 로직 추가

### DIFF
--- a/src/docs/ProductRestDocs.adoc
+++ b/src/docs/ProductRestDocs.adoc
@@ -29,3 +29,22 @@ include::{snippets}/products/get-products-by-market-and-category/http-response.a
 
 include::{snippets}/products/get-products-by-market-and-category/response-fields.adoc[]
 
+=== 2. 상품 상세 조회
+
+==== HTTP request
+
+include::{snippets}/products/get-product-details/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/products/get-product-details/path-parameters.adoc[]
+
+
+==== HTTP response
+
+include::{snippets}/products/get-product-details/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/products/get-product-details/response-fields.adoc[]
+

--- a/src/docs/ProductRestDocs.adoc
+++ b/src/docs/ProductRestDocs.adoc
@@ -1,0 +1,31 @@
+= API 문서
+Fondant Backend Team
+2025-01-26
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:sectlinks:
+
+== Product API
+
+=== 1. 마켓, 카테고리별 상품 목록 조회
+
+==== HTTP request
+
+include::{snippets}/products/get-products-by-market-and-category/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/products/get-products-by-market-and-category/path-parameters.adoc[]
+
+==== Query parameters
+include::{snippets}/products/get-products-by-market-and-category/query-parameters.adoc[]
+
+==== HTTP response
+
+include::{snippets}/products/get-products-by-market-and-category/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/products/get-products-by-market-and-category/response-fields.adoc[]
+

--- a/src/main/java/com/fondant/global/config/QueryDslConfig.java
+++ b/src/main/java/com/fondant/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.fondant.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/fondant/global/dto/PageInfo.java
+++ b/src/main/java/com/fondant/global/dto/PageInfo.java
@@ -1,0 +1,10 @@
+package com.fondant.global.dto;
+
+public record PageInfo(
+        int currentPage,
+        int totalPage
+) {
+    public static PageInfo of(int currentPage, int totalPage) {
+        return new PageInfo(currentPage, totalPage);
+    }
+}

--- a/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
+++ b/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
@@ -14,6 +15,7 @@ public class MarketEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="market_id")
+    @Getter
     private Long id;
 
     @NotNull

--- a/src/main/java/com/fondant/product/application/ProductService.java
+++ b/src/main/java/com/fondant/product/application/ProductService.java
@@ -1,0 +1,53 @@
+package com.fondant.product.application;
+
+import com.fondant.global.dto.PageInfo;
+import com.fondant.product.application.dto.ProductInfo;
+import com.fondant.product.domain.entity.ProductEntity;
+import com.fondant.product.domain.repository.ProductRepository;
+import com.fondant.product.presentation.dto.response.ProductsResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ProductService {
+    private final ProductRepository productRepository;
+
+    @Autowired
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ProductsResponse getProductsByMarketAndCategoryId(Long marketId, Long categoryId, Pageable pageable) {
+        Page<ProductEntity> products = productRepository.findProductsByMarketAndCategory(marketId,categoryId,pageable);
+
+        return ProductsResponse.builder()
+                .pageInfo(PageInfo.of(products.getNumber(), products.getTotalPages()))
+                .products(getProductInfos(products.getContent()))
+                .build();
+    }
+
+    private List<ProductInfo> getProductInfos(List<ProductEntity> products) {
+        return products.stream()
+                .map(product->
+                        ProductInfo.builder()
+                                .id(product.getId())
+                                .name(product.getName())
+                                .price(product.getPrice())
+                                .thumbnailUrl(product.getThumbnail())
+                                .discountRate(product.getDiscountRate())
+                                .discountPrice(getDiscountedPrice(product.getPrice(),product.getDiscountRate()))
+                                .build()
+                ).toList();
+    }
+
+    private int getDiscountedPrice(int price, double discountRate) {
+        double appliedRate = 1.0 - discountRate;
+        return (int) Math.floor(price * appliedRate + 0.5);
+    }
+}

--- a/src/main/java/com/fondant/product/application/ProductService.java
+++ b/src/main/java/com/fondant/product/application/ProductService.java
@@ -1,9 +1,11 @@
 package com.fondant.product.application;
 
 import com.fondant.global.dto.PageInfo;
+import com.fondant.global.exception.ApiException;
 import com.fondant.product.application.dto.ProductInfo;
 import com.fondant.product.domain.entity.ProductEntity;
 import com.fondant.product.domain.repository.ProductRepository;
+import com.fondant.product.exception.ProductError;
 import com.fondant.product.presentation.dto.response.ProductsResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -25,6 +27,10 @@ public class ProductService {
     @Transactional(readOnly = true)
     public ProductsResponse getProductsByMarketAndCategoryId(Long marketId, Long categoryId, Pageable pageable) {
         Page<ProductEntity> products = productRepository.findProductsByMarketAndCategory(marketId,categoryId,pageable);
+
+        if(products.isEmpty()){
+            throw new ApiException(ProductError.NO_PRODUCTS_FOUND);
+        }
 
         return ProductsResponse.builder()
                 .pageInfo(PageInfo.of(products.getNumber(), products.getTotalPages()))

--- a/src/main/java/com/fondant/product/application/ProductService.java
+++ b/src/main/java/com/fondant/product/application/ProductService.java
@@ -80,18 +80,24 @@ public class ProductService {
     }
 
     private List<String> getImageUrlsByProductIdAndType(Long productId,ImageType imageType){
-        return productImageRepository.findByProductIdAndImageType(productId,imageType)
+        return productImageRepository.findByProductIdAndImageType(productId, imageType)
                 .stream().map(ProductImageEntity::getImageUrl).toList();
     }
 
     private List<OptionInfo> getOptionInfos(Long productId){
          List<OptionEntity> options = optionRepository.findByProductId(productId);
+
+        if (options.isEmpty()) {
+            throw new ApiException(ProductError.OPTION_NOT_FOUND);
+        }
+
          return options.stream().map(option->
                  new OptionInfo(option.getId(),option.getName(),option.getPrice()))
                  .toList();
     }
 
-    private ProductEntity getProductById(Long productId){
-        return productRepository.findById(productId).orElseThrow();
+    private ProductEntity getProductById(Long productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new ApiException(ProductError.PRODUCT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/fondant/product/application/dto/OptionInfo.java
+++ b/src/main/java/com/fondant/product/application/dto/OptionInfo.java
@@ -1,0 +1,8 @@
+package com.fondant.product.application.dto;
+
+public record OptionInfo(
+        Long id,
+        String name,
+        int price
+) {
+}

--- a/src/main/java/com/fondant/product/application/dto/ProductInfo.java
+++ b/src/main/java/com/fondant/product/application/dto/ProductInfo.java
@@ -1,0 +1,15 @@
+package com.fondant.product.application.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ProductInfo(
+        Long id,
+        String name,
+        int price,
+        String thumbnailUrl,
+        double score,
+        double discountRate,
+        int discountPrice
+) {
+}

--- a/src/main/java/com/fondant/product/domain/entity/CategoryEntity.java
+++ b/src/main/java/com/fondant/product/domain/entity/CategoryEntity.java
@@ -2,9 +2,7 @@ package com.fondant.product.domain.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -13,20 +11,15 @@ public class CategoryEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="category_id")
+    @Getter
     private Long id;
 
     @NotNull
-    @Column(name="category_type")
-    @Enumerated(EnumType.STRING)
-    private CategoryType categoryType;
-
-    @NotNull
-    @Column(name="product_id")
-    private Long productId;
+    @Column(name="name")
+    private String name;
 
     @Builder
-    public CategoryEntity(CategoryType categoryType, Long productId) {
-        this.categoryType = categoryType;
-        this.productId = productId;
+    public CategoryEntity(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/com/fondant/product/domain/entity/CategoryType.java
+++ b/src/main/java/com/fondant/product/domain/entity/CategoryType.java
@@ -1,5 +1,0 @@
-package com.fondant.product.domain.entity;
-
-public enum CategoryType {
-    COOKIE,BAKERY,CHOCOLATE
-}

--- a/src/main/java/com/fondant/product/domain/entity/ImageType.java
+++ b/src/main/java/com/fondant/product/domain/entity/ImageType.java
@@ -1,0 +1,5 @@
+package com.fondant.product.domain.entity;
+
+public enum ImageType {
+     PRODUCT_PHOTO,DETAIL_PAGE
+}

--- a/src/main/java/com/fondant/product/domain/entity/OptionEntity.java
+++ b/src/main/java/com/fondant/product/domain/entity/OptionEntity.java
@@ -4,11 +4,13 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="option")
+@Getter
 public class OptionEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fondant/product/domain/entity/ProductCategoryEntity.java
+++ b/src/main/java/com/fondant/product/domain/entity/ProductCategoryEntity.java
@@ -1,0 +1,33 @@
+package com.fondant.product.domain.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name="product_category")
+public class ProductCategoryEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="product_category_id")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private ProductEntity product;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private CategoryEntity category;
+
+    @Builder
+    public ProductCategoryEntity(ProductEntity product, CategoryEntity category) {
+        this.product = product;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/fondant/product/domain/entity/ProductEntity.java
+++ b/src/main/java/com/fondant/product/domain/entity/ProductEntity.java
@@ -1,9 +1,11 @@
 package com.fondant.product.domain.entity;
 
+import com.fondant.market.domain.entity.MarketEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
@@ -11,6 +13,7 @@ import java.time.LocalDate;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="product")
+@Getter
 public class ProductEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="product_id")
@@ -30,11 +33,11 @@ public class ProductEntity {
 
     @NotNull
     @Column(name="price")
-    private String price;
+    private int price;
 
-    @NotNull
-    @Column(name="market_id")
-    private Long marketId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="market_id")
+    private MarketEntity market;
 
     @NotNull
     @Column(name="start_date")
@@ -49,12 +52,12 @@ public class ProductEntity {
     private double discountRate;
 
     @Builder
-    public ProductEntity(String name, String description, String thumbnail, String price, Long marketId, LocalDate startDate, int maxCount) {
+    public ProductEntity(String name, String description, String thumbnail, int price, MarketEntity market, LocalDate startDate, int maxCount) {
         this.name = name;
         this.description = description;
         this.thumbnail = thumbnail;
         this.price = price;
-        this.marketId = marketId;
+        this.market = market;
         this.startDate = startDate;
         this.maxCount = maxCount;
         this.discountRate = 0.0;

--- a/src/main/java/com/fondant/product/domain/entity/ProductImageEntity.java
+++ b/src/main/java/com/fondant/product/domain/entity/ProductImageEntity.java
@@ -1,0 +1,34 @@
+package com.fondant.product.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "product_image")
+@Getter
+public class ProductImageEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="product_image_id")
+    private Long id;
+
+    @Column(name="product_id")
+    private Long productId;
+
+    @Column(name="img_url")
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="img_type")
+    private  ImageType imageType;
+
+    @Builder
+    public ProductImageEntity(Long productId, String imageUrl, ImageType imageType) {
+        this.productId = productId;
+        this.imageUrl = imageUrl;
+        this.imageType = imageType;
+    }
+}

--- a/src/main/java/com/fondant/product/domain/repository/OptionRepository.java
+++ b/src/main/java/com/fondant/product/domain/repository/OptionRepository.java
@@ -1,0 +1,11 @@
+package com.fondant.product.domain.repository;
+
+import com.fondant.product.domain.entity.OptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import javax.swing.text.html.Option;
+import java.util.List;
+
+public interface OptionRepository extends JpaRepository<OptionEntity, Long> {
+    List<OptionEntity> findByProductId(Long productId);
+}

--- a/src/main/java/com/fondant/product/domain/repository/ProductImageRepository.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductImageRepository.java
@@ -1,0 +1,11 @@
+package com.fondant.product.domain.repository;
+
+import com.fondant.product.domain.entity.ImageType;
+import com.fondant.product.domain.entity.ProductImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductImageRepository extends JpaRepository<ProductImageEntity,Long> {
+    List<ProductImageEntity> findByProductIdAndImageType(Long productId, ImageType type);
+}

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.fondant.product.domain.repository;
+
+import com.fondant.product.domain.entity.ProductEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ProductRepository extends JpaRepository<ProductEntity,Long>,ProductRepositoryCustom {
+}

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.fondant.product.domain.repository;
+
+import com.fondant.product.domain.entity.ProductEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductRepositoryCustom {
+    Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long categoryId, Pageable pageable);
+}

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.fondant.product.domain.repository;
+
+import com.fondant.market.domain.entity.QMarketEntity;
+import com.fondant.product.domain.entity.ProductEntity;
+import com.fondant.product.domain.entity.QCategoryEntity;
+import com.fondant.product.domain.entity.QProductCategoryEntity;
+import com.fondant.product.domain.entity.QProductEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ProductRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long categoryId, Pageable pageable) {
+        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
+        QProductEntity product = QProductEntity.productEntity;
+        QMarketEntity market = QMarketEntity.marketEntity;
+
+        List<ProductEntity> content = queryFactory
+                .select(product)
+                .from(productCategory)
+                .join(productCategory.product, product)
+                .join(product.market, market)
+                .where(
+                        productCategory.category.id.eq(categoryId),
+                        product.market.id.eq(marketId)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(product.count())
+                .from(productCategory)
+                .join(productCategory.product, product)
+                .join(product.market, market)
+                .where(
+                        productCategory.category.id.eq(categoryId),
+                        product.market.id.eq(marketId)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}
+

--- a/src/main/java/com/fondant/product/exception/ProductError.java
+++ b/src/main/java/com/fondant/product/exception/ProductError.java
@@ -1,0 +1,40 @@
+package com.fondant.product.exception;
+
+import com.fondant.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ProductError implements ErrorCode {
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다.", "PRODUCT_NOT_FOUND"),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다.", "CATEGORY_NOT_FOUND"),
+    MARKET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마켓을 찾을 수 없습니다.", "MARKET_NOT_FOUND"),
+    NO_PRODUCTS_FOUND(HttpStatus.NO_CONTENT, "해당 마켓/카테고리에 상품이 없습니다.", "NO_PRODUCTS_FOUND"),
+    INVALID_MARKET_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 marketId입니다.", "INVALID_MARKET_ID"),
+    INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 categoryId입니다.", "INVALID_CATEGORY_ID"),
+    INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다.", "INVALID_PAGE_NUMBER");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String errorCode;
+
+    ProductError(final HttpStatus httpStatus, final String message, final String errorCode) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.errorCode = errorCode;
+    }
+
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+
+    @Override
+    public String getErrorCode() {
+        return "";
+    }
+}

--- a/src/main/java/com/fondant/product/exception/ProductError.java
+++ b/src/main/java/com/fondant/product/exception/ProductError.java
@@ -10,7 +10,8 @@ public enum ProductError implements ErrorCode {
     NO_PRODUCTS_FOUND(HttpStatus.NO_CONTENT, "해당 마켓/카테고리에 상품이 없습니다.", "NO_PRODUCTS_FOUND"),
     INVALID_MARKET_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 marketId입니다.", "INVALID_MARKET_ID"),
     INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 categoryId입니다.", "INVALID_CATEGORY_ID"),
-    INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다.", "INVALID_PAGE_NUMBER");
+    INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다.", "INVALID_PAGE_NUMBER"),
+    OPTION_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 상품의 옵션을 찾을 수 없습니다.", "OPTION_NOT_FOUND"),;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fondant/product/presentation/ProductController.java
+++ b/src/main/java/com/fondant/product/presentation/ProductController.java
@@ -3,6 +3,7 @@ package com.fondant.product.presentation;
 import com.fondant.global.dto.ResponseDto;
 import com.fondant.global.dto.SuccessMessage;
 import com.fondant.product.application.ProductService;
+import com.fondant.product.presentation.dto.response.ProductDetailResponse;
 import com.fondant.product.presentation.dto.response.ProductsResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,5 +31,12 @@ public class ProductController {
 
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
                 productService.getProductsByMarketAndCategoryId(marketId,categoryId,pageable)));
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ResponseDto<ProductDetailResponse>> getProductDetail(
+            @PathVariable(name="productId") Long productId) {
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                productService.getProductDetail(productId)));
     }
 }

--- a/src/main/java/com/fondant/product/presentation/ProductController.java
+++ b/src/main/java/com/fondant/product/presentation/ProductController.java
@@ -1,0 +1,34 @@
+package com.fondant.product.presentation;
+
+import com.fondant.global.dto.ResponseDto;
+import com.fondant.global.dto.SuccessMessage;
+import com.fondant.product.application.ProductService;
+import com.fondant.product.presentation.dto.response.ProductsResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/product")
+public class ProductController {
+    private static int PAGE_SIZE = 10;
+
+    private final ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @GetMapping("/{marketId}/{categoryId}")
+    public ResponseEntity<ResponseDto<ProductsResponse>> getProductsByMarketAndCategory(
+            @PathVariable(name="marketId") Long marketId,
+            @PathVariable(name="categoryId") Long categoryId,
+            @RequestParam(name="page") int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                productService.getProductsByMarketAndCategoryId(marketId,categoryId,pageable)));
+    }
+}

--- a/src/main/java/com/fondant/product/presentation/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/fondant/product/presentation/dto/response/ProductDetailResponse.java
@@ -1,0 +1,16 @@
+package com.fondant.product.presentation.dto.response;
+
+import com.fondant.product.application.dto.OptionInfo;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductDetailResponse(
+        List<String> photos,
+        String name,
+        List<OptionInfo> options,
+        String description,
+        List<String> detailPages
+) {
+}

--- a/src/main/java/com/fondant/product/presentation/dto/response/ProductsResponse.java
+++ b/src/main/java/com/fondant/product/presentation/dto/response/ProductsResponse.java
@@ -1,0 +1,21 @@
+package com.fondant.product.presentation.dto.response;
+
+import com.fondant.global.dto.PageInfo;
+import com.fondant.product.application.dto.ProductInfo;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Builder
+public record ProductsResponse(
+        PageInfo pageInfo,
+        List<ProductInfo> products
+) {
+    public static ProductsResponse of(List<ProductInfo> products,PageInfo pageInfo) {
+        return ProductsResponse.builder()
+                .pageInfo(pageInfo)
+                .products(products)
+                .build();
+    }
+}

--- a/src/main/java/com/fondant/test/repository/CategoryTestRepository.java
+++ b/src/main/java/com/fondant/test/repository/CategoryTestRepository.java
@@ -1,0 +1,7 @@
+package com.fondant.test.repository;
+
+import com.fondant.product.domain.entity.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryTestRepository extends JpaRepository<CategoryEntity,Long> {
+}

--- a/src/main/java/com/fondant/test/repository/MarketTestRepository.java
+++ b/src/main/java/com/fondant/test/repository/MarketTestRepository.java
@@ -1,0 +1,7 @@
+package com.fondant.test.repository;
+
+import com.fondant.market.domain.entity.MarketEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketTestRepository extends JpaRepository<MarketEntity,Long> {
+}

--- a/src/main/java/com/fondant/test/repository/ProductCategoryTestRepository.java
+++ b/src/main/java/com/fondant/test/repository/ProductCategoryTestRepository.java
@@ -1,0 +1,7 @@
+package com.fondant.test.repository;
+
+import com.fondant.product.domain.entity.ProductCategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductCategoryTestRepository extends JpaRepository<ProductCategoryEntity,Long> {
+}

--- a/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
@@ -1,0 +1,148 @@
+package com.fondant.restdocs;
+
+
+import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.product.domain.entity.CategoryEntity;
+import com.fondant.product.domain.entity.ProductCategoryEntity;
+import com.fondant.product.domain.entity.ProductEntity;
+import com.fondant.product.domain.repository.ProductRepository;
+import com.fondant.test.repository.CategoryTestRepository;
+import com.fondant.test.repository.MarketTestRepository;
+import com.fondant.test.repository.ProductCategoryTestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriScheme = "http", uriHost = "localhost", uriPort = 8080)
+@Transactional
+public class ProductRestDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private MarketTestRepository marketRepository;
+
+    @Autowired
+    private CategoryTestRepository categoryRepository;
+
+    @Autowired
+    private ProductCategoryTestRepository productCategoryRepository;
+
+    private MarketEntity market;
+    private CategoryEntity category1;
+    private CategoryEntity category2;
+    private ProductCategoryEntity categoryProduct1;
+    private ProductCategoryEntity categoryProduct2;
+    private ProductEntity product1;
+    private ProductEntity product2;
+
+    private static final String BASE_URL = "/api/product";
+
+    @BeforeEach
+    void setUp() {
+        market = marketRepository.save(MarketEntity.builder()
+                .name("퐁당 마켓")
+                .description("신메뉴 업데이트 매달 1일 ! 전국 택배가능 초콜릿 쿠키 전문 퐁당 마켓")
+                .thumbnail("test-thumbnail.png")
+                .background("test-background.png")
+                .build()
+        );
+
+        category1 = categoryRepository.save(CategoryEntity.builder()
+                .name("초콜릿")
+                .build());
+
+        category2 = categoryRepository.save(CategoryEntity.builder()
+                .name("쿠키")
+                .build());
+
+        product1 = productRepository.save(ProductEntity.builder()
+                .name("두바이 초콜릿")
+                .description("카다이프 듬뿍 두바이 초콜릿입니다.")
+                .thumbnail("product-thumbnail.png")
+                .price(15000)
+                .market(market)
+                .startDate(LocalDate.of(2025, 1, 1))
+                .maxCount(50)
+                .build());
+
+        product2 = productRepository.save(ProductEntity.builder()
+                .name("헤이즐넛 쿠키")
+                .description("헤이즐넛 쿠키 입니다.")
+                .thumbnail("product-thumbnail.png")
+                .price(15000)
+                .market(market)
+                .startDate(LocalDate.of(2025, 1, 1))
+                .maxCount(50)
+                .build());
+
+        categoryProduct1 = productCategoryRepository.save(ProductCategoryEntity.builder()
+                .product(product1)
+                .category(category1)
+                .build());
+    }
+
+    public static FieldDescriptor[] commonResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("code").description("요청 성공 여부 (true/false)"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("response").description("응답 데이터")
+        };
+    }
+
+    @Test
+    void getProductsByMarketAndCategory() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/{marketId}/{categoryId}", market.getId(), category1.getId())
+                        .param("page", "0")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("products/get-products-by-market-and-category",
+                        preprocessRequest(prettyPrint()),  // 요청 JSON 정렬
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("marketId").description("조회할 마켓의 ID"),
+                                parameterWithName("categoryId").description("조회할 카테고리의 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)")
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[] {
+                                fieldWithPath("pageInfo").description("페이지 정보"),
+                                fieldWithPath("pageInfo.currentPage").description("현재 페이지"),
+                                fieldWithPath("pageInfo.totalPage").description("전체 페이지"),
+                                fieldWithPath("products[].id").description("상품 ID"),
+                                fieldWithPath("products[].name").description("상품 이름"),
+                                fieldWithPath("products[].price").description("상품 가격"),
+                                fieldWithPath("products[].score").description("리뷰 평점"),
+                                fieldWithPath("products[].thumbnailUrl").description("상품 썸네일 URL"),
+                                fieldWithPath("products[].discountRate").description("상품 할인율"),
+                                fieldWithPath("products[].discountPrice").description("상품 할인 후 가격")
+                        })));
+    }
+}
+


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #17 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
### 1. 이미지 저장용 엔티티 추가
상품 이미지 종류를 상세페이지(`DETAIL_PAGE`), 상품이미지(`PRODUCT_PHOTO`) 두개로 구분하고
상품이 여러개의 이미지를 가질 수 있도록 엔티티를 구성하였습니다 .

### 2. 상품 상세 조회 로직 추가
상품 조회로직은 다음 api명세에 맞게 개발하였고 자세한 로직은 코드 참고 부탁드립니다.
<img width="508" alt="image" src="https://github.com/user-attachments/assets/abe7ac15-ac8d-4737-a7aa-db1bcac0b09c" />


## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
