### PR TITLE
[Feat] CurrentUser Custom Annotation 추가

### DIFF
--- a/src/main/java/com/fondant/global/annotation/CurrentUser.java
+++ b/src/main/java/com/fondant/global/annotation/CurrentUser.java
@@ -1,0 +1,16 @@
+package com.fondant.global.annotation;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Bean
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface CurrentUser {
+}

--- a/src/main/java/com/fondant/global/annotation/CurrentUser.java
+++ b/src/main/java/com/fondant/global/annotation/CurrentUser.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Bean
-@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Target({ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @AuthenticationPrincipal
 public @interface CurrentUser {


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #20 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->

JWT Filter의 authToken에서 userId와 role값을 뽑아내는 Custom Annotation을 만들었습니다.

작동방식은 다음과 같습니다.

1. 클라이언트가 JWT Token을 Authorization 헤더에 담아 요청합니다.
2. JWTFilter에서 토큰을 검증하고 토큰의 정보로 CustomUserDetails를 생성해 SecurityContextHolder에 저장합니다.
3. CurrentUser 어노테이션이 SecurityContext의 CustomUserDetails를 가져옵니다.

사용 방법은 다음과 같습니다.
```
@GetMapping("/my")
    public ResponseEntity<?> getUserInfo(@CurrentUser CustomUserDetails userDetails) {
        String userId = userDetails.getUserId();
        String role = userDetails.getAuthorities().iterator().next().getAuthority();

        return ResponseEntity.ok(Map.of(
                "userId", userId,
                "role", role
        ));
    } 
```
와 같이 파라미터로 CustomUserDetails를 받아와서 사용하면 됩니다.

## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
진짜 제가 그러면 안되지만 feature/#20 브랜치를 실수로 디벨롭에서 분기하지 않아서 feature/#15에 머지합니다,,, 정말 입이 백개라도 할말이 없습니다 정말 죄송합니다 ,,,,,,,,,,