### PR TITLE
[Feat] 마켓 관련 로직 추가

### DIFF
--- a/src/docs/MarketRestDocs.adoc
+++ b/src/docs/MarketRestDocs.adoc
@@ -1,0 +1,30 @@
+= API 문서
+Fondant Backend Team
+2025-01-26
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:sectlinks:
+
+== Market API
+
+=== 1. 카테고리별 마켓 목록 조회
+
+==== HTTP request
+
+include::{snippets}/markets/get-markets-by-category/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/markets/get-markets-by-category/path-parameters.adoc[]
+
+==== Query parameters
+include::{snippets}/markets/get-markets-by-category/query-parameters.adoc[]
+
+==== HTTP response
+
+include::{snippets}/markets/get-markets-by-category/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/markets/get-markets-by-category/response-fields.adoc[]

--- a/src/docs/MarketRestDocs.adoc
+++ b/src/docs/MarketRestDocs.adoc
@@ -28,3 +28,21 @@ include::{snippets}/markets/get-markets-by-category/http-response.adoc[]
 ==== response body
 
 include::{snippets}/markets/get-markets-by-category/response-fields.adoc[]
+
+=== 2. 마켓 상세 조회
+
+==== HTTP request
+
+include::{snippets}/markets/get-market-by-id/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/markets/get-market-by-id/path-parameters.adoc[]
+
+==== HTTP response
+
+include::{snippets}/markets/get-market-by-id/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/markets/get-market-by-id/response-fields.adoc[]

--- a/src/main/java/com/fondant/global/config/PageConfig.java
+++ b/src/main/java/com/fondant/global/config/PageConfig.java
@@ -1,0 +1,32 @@
+package com.fondant.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class PageConfig implements WebMvcConfigurer {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 10;
+    private static final int MAX_SIZE = 50;
+
+    @Bean
+    public Pageable defaultPageable() {
+        return PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        PageableHandlerMethodArgumentResolver resolver = new PageableHandlerMethodArgumentResolver();
+        resolver.setFallbackPageable(PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE));
+        resolver.setMaxPageSize(MAX_SIZE);
+        resolvers.add(resolver);
+    }
+}

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -2,6 +2,7 @@ package com.fondant.market.application;
 
 import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.PageInfo;
+import com.fondant.market.application.dto.MarketDetail;
 import com.fondant.market.application.dto.MarketInfo;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.market.domain.repository.MarketRepository;
@@ -17,13 +18,11 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class MarketService {
-
     private final MarketRepository marketRepository;
     private final PageConfig pageConfig;
 
     @Transactional(readOnly = true)
     public MarketsResponse getMarketsByCategoryId(Long categoryId, Pageable pageable) {
-
         Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
         Page<MarketEntity> markets = this.marketRepository.findMarketsByCategory(categoryId, effectivePageable);
 
@@ -31,6 +30,14 @@ public class MarketService {
                 .pageInfo(PageInfo.of(markets.getNumber(), markets.getTotalPages()))
                 .markets(getMarketInfos(markets.getContent()))
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public MarketDetail getMarketById(Long marketId) {
+        MarketEntity market = marketRepository.findById(marketId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 마켓을 찾을 수 없습니다. ID: " + marketId));
+
+        return convertToDetailDto(market);
     }
 
     private List<MarketInfo> getMarketInfos(List<MarketEntity> markets) {
@@ -42,5 +49,18 @@ public class MarketService {
                         .thumbnail(market.getThumbnail())
                         .build())
                 .toList();
+    }
+
+    private MarketDetail convertToDetailDto(MarketEntity market) {
+        return MarketDetail.builder()
+                .id(market.getId())
+                .name(market.getName())
+                .description(market.getDescription())
+                .thumbnail(market.getThumbnail())
+                .background(market.getBackground())
+                .totalSales(market.getTotalSales())
+                .totalReviews(market.getTotalReviews())
+                .deliveryFee(market.getDeliveryFee())
+                .build();
     }
 }

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -1,0 +1,54 @@
+package com.fondant.market.application;
+
+import com.fondant.global.dto.PageInfo;
+import com.fondant.market.application.dto.MarketInfo;
+import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.market.domain.repository.MarketRepository;
+import com.fondant.market.presentation.dto.response.MarketsResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class MarketService {
+    private final MarketRepository marketRepository;
+
+    @Autowired
+    public MarketService(MarketRepository marketRepository) {
+        this.marketRepository = marketRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MarketsResponse getMarketsByCategoryId(Long categoryId, Pageable pageable) {
+        Page<MarketEntity> markets = marketRepository.findMarketsByCategory(categoryId,pageable);
+
+        return MarketsResponse.builder()
+                .pageInfo(PageInfo.of(markets.getNumber(), markets.getTotalPages()))
+                .markets(getMarketInfos(markets.getContent()))
+                .build();
+    }
+
+    private List<MarketInfo> getMarketInfos(List<MarketEntity> markets) {
+        return markets.stream()
+                .map(market -> MarketInfo.builder()
+                        .id(market.getId())
+                        .name(market.getName())
+                        .description(market.getDescription())
+                        .thumbnail(market.getThumbnail())
+                        .build())
+                .toList();
+    }
+
+    private MarketInfo convertToDto(MarketEntity market) {
+        return MarketInfo.builder()
+                .id(market.getId())
+                .name(market.getName())
+                .description(market.getDescription())
+                .thumbnail(market.getThumbnail())
+                .build();
+    }
+}

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -2,10 +2,12 @@ package com.fondant.market.application;
 
 import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.PageInfo;
+import com.fondant.global.exception.ApiException;
 import com.fondant.market.application.dto.MarketDetail;
 import com.fondant.market.application.dto.MarketInfo;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.market.domain.repository.MarketRepository;
+import com.fondant.market.exception.MarketError;
 import com.fondant.market.presentation.dto.response.MarketsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,8 +25,16 @@ public class MarketService {
 
     @Transactional(readOnly = true)
     public MarketsResponse getMarketsByCategoryId(Long categoryId, Pageable pageable) {
+        if (categoryId == null || categoryId <= 0) {
+            throw new ApiException(MarketError.INVALID_CATEGORY_ID);
+        }
+
         Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
-        Page<MarketEntity> markets = this.marketRepository.findMarketsByCategory(categoryId, effectivePageable);
+        Page<MarketEntity> markets = marketRepository.findMarketsByCategory(categoryId, effectivePageable);
+
+        if (markets.isEmpty()) {
+            throw new ApiException(MarketError.NO_MARKETS_FOUND);
+        }
 
         return MarketsResponse.builder()
                 .pageInfo(PageInfo.of(markets.getNumber(), markets.getTotalPages()))
@@ -34,8 +44,12 @@ public class MarketService {
 
     @Transactional(readOnly = true)
     public MarketDetail getMarketById(Long marketId) {
+        if (marketId == null || marketId <= 0) {
+            throw new ApiException(MarketError.INVALID_MARKET_ID);
+        }
+
         MarketEntity market = marketRepository.findById(marketId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 마켓을 찾을 수 없습니다. ID: " + marketId));
+                .orElseThrow(() -> new ApiException(MarketError.MARKET_NOT_FOUND));
 
         return convertToDetailDto(market);
     }

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -58,9 +58,6 @@ public class MarketService {
                 .description(market.getDescription())
                 .thumbnail(market.getThumbnail())
                 .background(market.getBackground())
-                .totalSales(market.getTotalSales())
-                .totalReviews(market.getTotalReviews())
-                .deliveryFee(market.getDeliveryFee())
                 .build();
     }
 }

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -1,5 +1,6 @@
 package com.fondant.market.application;
 
+import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.PageInfo;
 import com.fondant.market.application.dto.MarketInfo;
 import com.fondant.market.domain.entity.MarketEntity;
@@ -18,10 +19,13 @@ import java.util.List;
 public class MarketService {
 
     private final MarketRepository marketRepository;
+    private final PageConfig pageConfig;
 
     @Transactional(readOnly = true)
     public MarketsResponse getMarketsByCategoryId(Long categoryId, Pageable pageable) {
-        Page<MarketEntity> markets = marketRepository.findMarketsByCategory(categoryId,pageable);
+
+        Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
+        Page<MarketEntity> markets = this.marketRepository.findMarketsByCategory(categoryId, effectivePageable);
 
         return MarketsResponse.builder()
                 .pageInfo(PageInfo.of(markets.getNumber(), markets.getTotalPages()))

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -42,13 +42,4 @@ public class MarketService {
                         .build())
                 .toList();
     }
-
-    private MarketInfo convertToDto(MarketEntity market) {
-        return MarketInfo.builder()
-                .id(market.getId())
-                .name(market.getName())
-                .description(market.getDescription())
-                .thumbnail(market.getThumbnail())
-                .build();
-    }
 }

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -5,7 +5,7 @@ import com.fondant.market.application.dto.MarketInfo;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.market.domain.repository.MarketRepository;
 import com.fondant.market.presentation.dto.response.MarketsResponse;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,13 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class MarketService {
-    private final MarketRepository marketRepository;
 
-    @Autowired
-    public MarketService(MarketRepository marketRepository) {
-        this.marketRepository = marketRepository;
-    }
+    private final MarketRepository marketRepository;
 
     @Transactional(readOnly = true)
     public MarketsResponse getMarketsByCategoryId(Long categoryId, Pageable pageable) {

--- a/src/main/java/com/fondant/market/application/dto/MarketDetail.java
+++ b/src/main/java/com/fondant/market/application/dto/MarketDetail.java
@@ -1,0 +1,29 @@
+package com.fondant.market.application.dto;
+
+import com.fondant.market.domain.entity.MarketEntity;
+import lombok.Builder;
+
+@Builder
+public record MarketDetail(
+        Long id,
+        String name,
+        String description,
+        String thumbnail,
+        String background,
+        Long totalSales,
+        Long totalReviews,
+        Long deliveryFee
+) {
+    public static MarketDetail of(MarketEntity market) {
+        return MarketDetail.builder()
+                .id(market.getId())
+                .name(market.getName())
+                .description(market.getDescription())
+                .thumbnail(market.getThumbnail())
+                .background(market.getBackground())
+                .totalSales(market.getTotalSales())
+                .totalReviews(market.getTotalReviews())
+                .deliveryFee(market.getDeliveryFee())
+                .build();
+    }
+}

--- a/src/main/java/com/fondant/market/application/dto/MarketDetail.java
+++ b/src/main/java/com/fondant/market/application/dto/MarketDetail.java
@@ -9,10 +9,7 @@ public record MarketDetail(
         String name,
         String description,
         String thumbnail,
-        String background,
-        Long totalSales,
-        Long totalReviews,
-        Long deliveryFee
+        String background
 ) {
     public static MarketDetail of(MarketEntity market) {
         return MarketDetail.builder()
@@ -21,9 +18,6 @@ public record MarketDetail(
                 .description(market.getDescription())
                 .thumbnail(market.getThumbnail())
                 .background(market.getBackground())
-                .totalSales(market.getTotalSales())
-                .totalReviews(market.getTotalReviews())
-                .deliveryFee(market.getDeliveryFee())
                 .build();
     }
 }

--- a/src/main/java/com/fondant/market/application/dto/MarketInfo.java
+++ b/src/main/java/com/fondant/market/application/dto/MarketInfo.java
@@ -1,0 +1,13 @@
+package com.fondant.market.application.dto;
+
+import lombok.Builder;
+@Builder
+public record MarketInfo (
+        Long id,
+        String name,
+        Long totalSales,
+        Long totalReviews,
+        String description,
+        String thumbnail
+) {
+}

--- a/src/main/java/com/fondant/market/domain/entity/MarketCategoryEntity.java
+++ b/src/main/java/com/fondant/market/domain/entity/MarketCategoryEntity.java
@@ -1,0 +1,34 @@
+package com.fondant.market.domain.entity;
+
+import com.fondant.product.domain.entity.CategoryEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name="market_category")
+public class MarketCategoryEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="market_category_id")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "market_id")
+    private MarketEntity market;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private CategoryEntity category;
+
+    @Builder
+    public MarketCategoryEntity(MarketEntity market, CategoryEntity category) {
+        this.market = market;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
+++ b/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
@@ -2,12 +2,11 @@ package com.fondant.market.domain.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
 import java.time.LocalDate;
 
+@ToString
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -52,7 +51,8 @@ public class MarketEntity {
     @Column(name="delivery_fee", nullable = false)
     private long deliveryFee;
 
-    @Builder MarketEntity(String name, Long totalSales, Long totalReviews, LocalDate createAt, LocalDate updateAt, String description, String thumbnail, String background, long deliveryFee) {
+    @Builder
+    MarketEntity(String name, Long totalSales, Long totalReviews, LocalDate createAt, LocalDate updateAt, String description, String thumbnail, String background, long deliveryFee) {
         this.name = name;
         this.totalSales = 0L;
         this.totalReviews = 0L;
@@ -63,4 +63,5 @@ public class MarketEntity {
         this.background = background;
         this.deliveryFee = 0L;
     }
+
 }

--- a/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
+++ b/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="market")
@@ -15,7 +16,6 @@ public class MarketEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="market_id")
-    @Getter
     private Long id;
 
     @NotNull

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepository.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepository.java
@@ -1,0 +1,7 @@
+package com.fondant.market.domain.repository;
+
+import com.fondant.market.domain.entity.MarketEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketRepository extends JpaRepository<MarketEntity, Long>,MarketRepositoryCustom {
+}

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.fondant.market.domain.repository;
+
+
+import com.fondant.market.domain.entity.MarketEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MarketRepositoryCustom {
+    Page<MarketEntity> findMarketsByCategory(Long categoryId, Pageable pageable);
+}

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -31,7 +31,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 .join(marketCategory.market, market)
                 .join(marketCategory.category, category)
                 .where(category.id.eq(categoryId))
-                .offset(pageable.getOffset()) // 페이지네이션 적용
+                .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.fondant.market.domain.repository;
+
+import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.market.domain.entity.QMarketCategoryEntity;
+import com.fondant.market.domain.entity.QMarketEntity;
+import com.fondant.product.domain.entity.QCategoryEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class MarketRepositoryImpl implements MarketRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MarketRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<MarketEntity> findMarketsByCategory(Long categoryId, Pageable pageable) {
+        QMarketEntity market = QMarketEntity.marketEntity;
+        QMarketCategoryEntity marketCategory = QMarketCategoryEntity.marketCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        List<MarketEntity> content = queryFactory
+                .selectDistinct(market)
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(category.id.eq(categoryId))
+                .offset(pageable.getOffset()) // 페이지네이션 적용
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(market.count())
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(category.id.eq(categoryId))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/fondant/market/exception/MarketError.java
+++ b/src/main/java/com/fondant/market/exception/MarketError.java
@@ -1,0 +1,38 @@
+package com.fondant.market.exception;
+
+import com.fondant.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum MarketError implements ErrorCode {
+    MARKET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마켓을 찾을 수 없습니다.", "MARKET_NOT_FOUND"),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다.", "CATEGORY_NOT_FOUND"),
+    NO_MARKETS_FOUND(HttpStatus.NO_CONTENT, "해당 카테고리에 등록된 마켓이 없습니다.", "NO_MARKETS_FOUND"),
+    INVALID_MARKET_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 marketId입니다.", "INVALID_MARKET_ID"),
+    INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 categoryId입니다.", "INVALID_CATEGORY_ID"),
+    INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다.", "INVALID_PAGE_NUMBER");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String errorCode;
+
+    MarketError(final HttpStatus httpStatus, final String message, final String errorCode) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -4,6 +4,7 @@ import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.ResponseDto;
 import com.fondant.global.dto.SuccessMessage;
 import com.fondant.market.application.MarketService;
+import com.fondant.market.application.dto.MarketDetail;
 import com.fondant.market.presentation.dto.response.MarketsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -19,8 +20,9 @@ public class MarketController {
     private final PageConfig pageConfig;
 
     @GetMapping("/{marketId}")
-    public ResponseEntity<Object> getMarket(@PathVariable long marketId) {
-        return ResponseEntity.ok(null);
+    public ResponseEntity<ResponseDto<MarketDetail>> getMarket(@PathVariable long marketId) {
+        MarketDetail marketDetail = marketService.getMarketById(marketId);
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, marketDetail));
     }
 
     @GetMapping("/categories/{categoryId}")

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -5,22 +5,25 @@ import com.fondant.global.dto.ResponseDto;
 import com.fondant.global.dto.SuccessMessage;
 import com.fondant.market.application.MarketService;
 import com.fondant.market.presentation.dto.response.MarketsResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/market")
+@RequiredArgsConstructor
+@RequestMapping("/api/markets")
 public class MarketController {
 
     private final MarketService marketService;
     private final PageConfig pageConfig;
 
-    public MarketController(MarketService marketService) {
-        this.marketService = marketService;
+    @GetMapping("/{marketId}")
+    public ResponseEntity<Object> getMarket(@PathVariable long marketId) {
+        return ResponseEntity.ok(null);
     }
 
-    @GetMapping("/{categoryId}")
+    @GetMapping("/categories/{categoryId}")
     public ResponseEntity<ResponseDto<MarketsResponse>> getMarketsByCategoryId(
             @PathVariable(name = "categoryId") Long categoryId,
             @RequestParam(required = false) Pageable pageable) {

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -1,10 +1,10 @@
 package com.fondant.market.presentation;
 
+import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.ResponseDto;
 import com.fondant.global.dto.SuccessMessage;
 import com.fondant.market.application.MarketService;
 import com.fondant.market.presentation.dto.response.MarketsResponse;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/market")
 public class MarketController {
-    private static final int PAGE_SIZE = 10;
 
     private final MarketService marketService;
+    private final PageConfig pageConfig;
 
     public MarketController(MarketService marketService) {
         this.marketService = marketService;
@@ -23,10 +23,11 @@ public class MarketController {
     @GetMapping("/{categoryId}")
     public ResponseEntity<ResponseDto<MarketsResponse>> getMarketsByCategoryId(
             @PathVariable(name = "categoryId") Long categoryId,
-            @RequestParam(name = "page") int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+            @RequestParam(required = false) Pageable pageable) {
+
+        Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
 
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
-                marketService.getMarketsByCategoryId(categoryId, pageable)));
+                marketService.getMarketsByCategoryId(categoryId, effectivePageable)));
     }
 }

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -1,0 +1,32 @@
+package com.fondant.market.presentation;
+
+import com.fondant.global.dto.ResponseDto;
+import com.fondant.global.dto.SuccessMessage;
+import com.fondant.market.application.MarketService;
+import com.fondant.market.presentation.dto.response.MarketsResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/market")
+public class MarketController {
+    private static final int PAGE_SIZE = 10;
+
+    private final MarketService marketService;
+
+    public MarketController(MarketService marketService) {
+        this.marketService = marketService;
+    }
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<ResponseDto<MarketsResponse>> getMarketsByCategoryId(
+            @PathVariable(name = "categoryId") Long categoryId,
+            @RequestParam(name = "page") int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                marketService.getMarketsByCategoryId(categoryId, pageable)));
+    }
+}

--- a/src/main/java/com/fondant/market/presentation/dto/response/MarketsResponse.java
+++ b/src/main/java/com/fondant/market/presentation/dto/response/MarketsResponse.java
@@ -1,0 +1,20 @@
+package com.fondant.market.presentation.dto.response;
+
+import com.fondant.global.dto.PageInfo;
+import com.fondant.market.application.dto.MarketInfo;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MarketsResponse(
+    PageInfo pageInfo,
+    List<MarketInfo> markets
+) {
+        public static MarketsResponse of(List<MarketInfo> markets,PageInfo pageInfo) {
+            return MarketsResponse.builder()
+                    .pageInfo(pageInfo)
+                    .markets(markets)
+                    .build();
+        }
+}

--- a/src/main/java/com/fondant/test/repository/MarketCategoryTestRepository.java
+++ b/src/main/java/com/fondant/test/repository/MarketCategoryTestRepository.java
@@ -1,0 +1,7 @@
+package com.fondant.test.repository;
+
+import com.fondant.market.domain.entity.MarketCategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketCategoryTestRepository extends JpaRepository<MarketCategoryEntity,Long> {
+}

--- a/src/test/java/com/fondant/market/domain/entity/MarketEntityTest.java
+++ b/src/test/java/com/fondant/market/domain/entity/MarketEntityTest.java
@@ -1,0 +1,14 @@
+package com.fondant.market.domain.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MarketEntityTest {
+
+    @Test
+    void builder() {
+        MarketEntity.builder()
+                .build();
+    }
+}

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -1,0 +1,113 @@
+package com.fondant.restdocs;
+
+import com.fondant.market.domain.entity.MarketCategoryEntity;
+import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.product.domain.entity.CategoryEntity;
+import com.fondant.test.repository.CategoryTestRepository;
+import com.fondant.test.repository.MarketCategoryTestRepository;
+import com.fondant.test.repository.MarketTestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.fondant.restdocs.ProductRestDocsTest.commonResponseFields;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriScheme = "http", uriHost = "localhost", uriPort = 8080)
+@Transactional
+public class MarketRestDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MarketTestRepository marketRepository;
+
+    @Autowired
+    private CategoryTestRepository categoryRepository;
+
+    @Autowired
+    private MarketCategoryTestRepository marketCategoryRepository;
+
+    private MarketEntity market1;
+    private MarketEntity market2;
+    private CategoryEntity category;
+
+    private static final String BASE_URL = "/api/market";
+
+    @BeforeEach
+    void setUp() {
+        category = categoryRepository.save(CategoryEntity.builder()
+                .name("쿠키")
+                .build());
+
+        market1 = marketRepository.save(MarketEntity.builder()
+                .name("Market A")
+                .description("쿠키를 판매하는 마켓 A")
+                .thumbnail("market-a-thumbnail.jpg")
+                .background("market-a-bg.jpg")
+                .build());
+
+        market2 = marketRepository.save(MarketEntity.builder()
+                .name("Market B")
+                .description("쿠키를 판매하는 마켓 B")
+                .thumbnail("market-b-thumbnail.jpg")
+                .background("market-b-bg.jpg")
+                .build());
+
+        marketCategoryRepository.save(MarketCategoryEntity.builder()
+                .market(market1)
+                .category(category)
+                .build());
+
+        marketCategoryRepository.save(MarketCategoryEntity.builder()
+                .market(market2)
+                .category(category)
+                .build());
+    }
+
+    @Test
+    void getMarketsByCategory() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/{categoryId}", category.getId())
+                        .param("page", "0")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("markets/get-markets-by-category",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("categoryId").description("조회할 카테고리 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)")
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
+                                fieldWithPath("pageInfo").description("페이지 정보"),
+                                fieldWithPath("pageInfo.currentPage").description("현재 페이지"),
+                                fieldWithPath("pageInfo.totalPage").description("전체 페이지"),
+                                fieldWithPath("markets[].id").description("마켓 ID"),
+                                fieldWithPath("markets[].name").description("마켓 이름"),
+                                fieldWithPath("markets[].description").description("마켓 한줄 소개"),
+                                fieldWithPath("markets[].thumbnail").description("마켓 썸네일 이미지 URL"),
+                                fieldWithPath("markets[].totalSales").description("마켓의 총 판매량"),
+                                fieldWithPath("markets[].totalReviews").description("마켓의 총 리뷰 수")
+                        })));
+    }
+}

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -110,4 +110,29 @@ public class MarketRestDocsTest {
                                 fieldWithPath("markets[].totalReviews").description("마켓의 총 리뷰 수")
                         })));
     }
+
+    @Test
+    void getMarketById() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/{marketId}", market1.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("markets/get-market-by-id",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("marketId").description("조회할 마켓 ID")
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
+                                fieldWithPath("id").description("마켓 ID"),
+                                fieldWithPath("name").description("마켓 이름"),
+                                fieldWithPath("description").description("마켓 한줄 소개"),
+                                fieldWithPath("thumbnail").description("마켓 썸네일 이미지 URL"),
+                                fieldWithPath("background").description("마켓 배경 이미지 URL"),
+                                fieldWithPath("totalSales").description("마켓의 총 판매량"),
+                                fieldWithPath("totalReviews").description("마켓의 총 리뷰 수"),
+                                fieldWithPath("deliveryFee").description("마켓의 배달비")
+                        })));
+    }
 }

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -48,7 +48,7 @@ public class MarketRestDocsTest {
     private MarketEntity market2;
     private CategoryEntity category;
 
-    private static final String BASE_URL = "/api/market";
+    private static final String BASE_URL = "/api/markets";
 
     @BeforeEach
     void setUp() {
@@ -83,7 +83,7 @@ public class MarketRestDocsTest {
 
     @Test
     void getMarketsByCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/{categoryId}", category.getId())
+        mockMvc.perform(get(BASE_URL + "/categories/{categoryId}", category.getId())
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -129,10 +129,7 @@ public class MarketRestDocsTest {
                                 fieldWithPath("name").description("마켓 이름"),
                                 fieldWithPath("description").description("마켓 한줄 소개"),
                                 fieldWithPath("thumbnail").description("마켓 썸네일 이미지 URL"),
-                                fieldWithPath("background").description("마켓 배경 이미지 URL"),
-                                fieldWithPath("totalSales").description("마켓의 총 판매량"),
-                                fieldWithPath("totalReviews").description("마켓의 총 리뷰 수"),
-                                fieldWithPath("deliveryFee").description("마켓의 배달비")
+                                fieldWithPath("background").description("마켓 배경 이미지 URL")
                         })));
     }
 }


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #14 
- close #26 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
카테고리별 마켓 목록 조회와 마켓 상세 조회를 함께 올리느라 pr이 늦어진 점 죄송합니다...
### 1️⃣ 페이지네이션 처리 방식 개선
- `pageable`이 `null`일 경우 기본 페이지네이션 값 `defaultPageable()`을 적용하여 `NullPointerException` 발생 가능성을 제거합니다.
- `pageConfig.defaultPageable()`을 통해 기본 페이지 0, 기본 사이즈 10을 유지합니다.
- 호출 시 `Pageable`을 주지 않아도 동작 가능합니다.
- 최대 페이지 크기를 설정할 수 있습니다. (`PageConfig`에서 `setMaxPageSize(50)` 설정됨). 
-> 이 부분의 필요성은 아직 모호한 것 같아서 의견 주시면 반영하겠습니다!

### 2️⃣ restdocs 문서
![목록조회](https://github.com/user-attachments/assets/22634431-06f1-4e9c-8c3f-03fa390deca2)



## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
혹시 예외 처리도 따로 테스트를 만들어서 문서화해야 할까요??