### PR TITLE
[Feat] 유저 조회 및 수정기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-
 	//OAUTH2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
@@ -48,7 +47,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 
 	//JWT
-
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+	//SPRING_SECURITY_TEST
+	testImplementation 'org.springframework.security:spring-security-test'
+
 	//JWT
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/docs/UserRestDocs.adoc
+++ b/src/docs/UserRestDocs.adoc
@@ -1,0 +1,100 @@
+= API 문서
+Fondant Backend Team
+2025-02-16
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:sectlinks:
+
+== User API
+=== 1. Access Token 재발급
+
+==== HTTP Request
+
+include::{snippets}/user/reissue-access-and-refresh-token/http-request.adoc[]
+
+==== Request Cookie
+
+include::{snippets}/user/reissue-access-and-refresh-token/request-cookies.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/user/reissue-access-and-refresh-token/http-response.adoc[]
+
+==== Response Cookie
+
+include::{snippets}/user/reissue-access-and-refresh-token/request-cookies.adoc[]
+
+==== Response Body
+
+include::{snippets}/user/reissue-access-and-refresh-token/response-body.adoc[]
+
+==== Response Field
+
+include::{snippets}/user/reissue-access-and-refresh-token/response-fields.adoc[]
+
+=== 2. 로그아웃
+
+==== HTTP Request
+
+include::{snippets}/user/logout/http-request.adoc[]
+
+==== Request Cookie
+
+include::{snippets}/user/logout/request-cookies.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/user/logout/http-response.adoc[]
+
+==== Response Body
+
+include::{snippets}/user/logout/response-fields.adoc[]
+
+=== 3. 유저 정보 조회
+
+==== HTTP Request
+
+include::{snippets}/user/get-user-info/http-request.adoc[]
+
+==== Request Header
+
+include::{snippets}/user/get-user-info/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/user/get-user-info/http-response.adoc[]
+
+==== Response Field
+
+include::{snippets}/user/get-user-info/response-fields.adoc[]
+
+=== 4. 유저 정보 수정
+
+==== HTTP Request
+
+include::{snippets}/user/update-user-info/http-request.adoc[]
+
+==== Request Header
+
+include::{snippets}/user/update-user-info/request-headers.adoc[]
+
+==== Request Body
+
+include::{snippets}/user/update-user-info/request-body.adoc[]
+
+==== Request Field
+
+include::{snippets}/user/update-user-info/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/user/update-user-info/http-response.adoc[]
+
+==== Response Body
+
+include::{snippets}/user/update-user-info/response-body.adoc[]
+
+==== Response Field
+
+include::{snippets}/user/update-user-info/response-fields.adoc[]

--- a/src/main/java/com/fondant/test/repository/UserTestRepository.java
+++ b/src/main/java/com/fondant/test/repository/UserTestRepository.java
@@ -1,0 +1,8 @@
+package com.fondant.test.repository;
+
+import com.fondant.user.domain.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTestRepository extends JpaRepository<UserEntity,Long> {
+    UserEntity findByEmail(String email);
+}

--- a/src/main/java/com/fondant/user/application/UserService.java
+++ b/src/main/java/com/fondant/user/application/UserService.java
@@ -1,0 +1,93 @@
+package com.fondant.user.application;
+
+import com.fondant.global.exception.ApiException;
+import com.fondant.user.exception.UserError;
+import com.fondant.user.presentation.dto.request.JoinRequest;
+import com.fondant.user.domain.entity.SNSType;
+import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.domain.entity.UserRole;
+import com.fondant.user.domain.repository.UserRepository;
+import com.fondant.user.presentation.dto.request.UserUpdateRequest;
+import com.fondant.user.presentation.dto.response.UserResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Autowired
+    public UserService(UserRepository userRepository, BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.userRepository = userRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    public UserResponse getUserInfo(Long userId) {
+        Optional<UserEntity> userEntityOptional = userRepository.findById(userId);
+
+        UserEntity userEntity = userEntityOptional.orElseThrow(() -> new ApiException(UserError.USER_NOT_FOUND));
+
+        return UserResponse.builder()
+                .name(userEntity.getName())
+                .phoneNumber(userEntity.getPhoneNumber())
+                .verifiedPhone(userEntity.isVerifiedPhone())
+                .email(userEntity.getEmail())
+                .birth(userEntity.getBirth())
+                .nickname(userEntity.getNickname())
+                .profileUrl(userEntity.getProfileUrl())
+                .gender(userEntity.getGender())
+                .build();
+    }
+
+    @Transactional
+    public void updateUserInfo(Long userId, UserUpdateRequest request) {
+        Optional<UserEntity> userEntityOptional = userRepository.findById(userId);
+
+        UserEntity userEntity = userEntityOptional.orElseThrow(() -> new ApiException(UserError.USER_NOT_FOUND));
+
+        userEntity = userEntity.toBuilder()
+                .name(request.name())
+                .phoneNumber(request.phoneNumber())
+                .verifiedPhone(request.verifiedPhone())
+                .email(request.email())
+                .birth(request.birth())
+                .nickname(request.nickname())
+                .profileUrl(request.profileUrl())
+                .gender(request.gender())
+                .build();
+
+        userRepository.save(userEntity);
+    }
+
+    @Transactional
+    public UserEntity joinUser(JoinRequest request) {
+
+        if (userRepository.findByEmail(request.email()).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+
+        UserEntity userEntity = UserEntity.builder()
+                .snsType(SNSType.LOCAL)
+                .name(request.name())
+                .phoneNumber(request.phoneNumber())
+                .email(request.email())
+                .password(bCryptPasswordEncoder.encode(request.password()))
+                .birth(request.birth())
+                .nickname("")
+                .profileUrl("")
+                .createAt(LocalDate.now())
+                .gender(request.gender())
+                .role(UserRole.USER)
+                .build();
+
+        return userRepository.save(userEntity);
+    }
+}

--- a/src/main/java/com/fondant/user/exception/UserError.java
+++ b/src/main/java/com/fondant/user/exception/UserError.java
@@ -1,0 +1,33 @@
+package com.fondant.user.exception;
+
+import com.fondant.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum UserError implements ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.", "USER_NOT_FOUND");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String errorCode;
+
+    UserError(final HttpStatus httpStatus, final String message, final String errorCode) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+
+    @Override
+    public String getErrorCode() {
+        return "";
+    }
+}

--- a/src/main/java/com/fondant/user/presentation/UserController.java
+++ b/src/main/java/com/fondant/user/presentation/UserController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 
 @Controller
-@RequestMapping("api/user")
+@RequestMapping("/api/user")
 public class UserController {
 
     private final UserService userService;
@@ -32,13 +32,13 @@ public class UserController {
         this.reissueService = reissueService;
     }
 
-    @GetMapping("/")
+    @GetMapping("")
     public ResponseEntity<ResponseDto<UserResponse>> getUserInfo(@CurrentUser CustomUserDetails user) {
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
                 userService.getUserInfo(user.getUserId())));
     }
 
-    @PatchMapping("/")
+    @PatchMapping("")
     public ResponseEntity<ResponseDto<Void>> updateUserInfo(@CurrentUser CustomUserDetails user, @RequestBody UserUpdateRequest request) {
         userService.updateUserInfo(user.getUserId(), request);
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));

--- a/src/main/java/com/fondant/user/presentation/UserController.java
+++ b/src/main/java/com/fondant/user/presentation/UserController.java
@@ -1,0 +1,48 @@
+package com.fondant.user.presentation;
+
+import com.fondant.global.annotation.CurrentUser;
+import com.fondant.global.dto.ResponseDto;
+import com.fondant.global.dto.SuccessMessage;
+import com.fondant.user.application.ReissueService;
+import com.fondant.user.application.UserService;
+import com.fondant.user.application.dto.CustomUserDetails;
+import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.presentation.dto.request.UserUpdateRequest;
+import com.fondant.user.presentation.dto.response.UserResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@Controller
+@RequestMapping("api/user")
+public class UserController {
+
+    private final UserService userService;
+    private final ReissueService reissueService;
+
+    public UserController(UserService userService, ReissueService reissueService) {
+        this.userService = userService;
+        this.reissueService = reissueService;
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<ResponseDto<UserResponse>> getUserInfo(@CurrentUser CustomUserDetails user) {
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                userService.getUserInfo(user.getUserId())));
+    }
+
+    @PatchMapping("/")
+    public ResponseEntity<ResponseDto<Void>> updateUserInfo(@CurrentUser CustomUserDetails user, @RequestBody UserUpdateRequest request) {
+        userService.updateUserInfo(user.getUserId(), request);
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        return reissueService.reissueToken(request, response);
+    }
+}

--- a/src/main/java/com/fondant/user/presentation/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/fondant/user/presentation/dto/request/UserUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.fondant.user.presentation.dto.request;
+
+import com.fondant.user.domain.entity.Gender;
+import lombok.Builder;
+
+import java.sql.Date;
+
+@Builder
+public record UserUpdateRequest(
+        String name,
+        String phoneNumber,
+        boolean verifiedPhone,
+        String email,
+        Date birth,
+        String nickname,
+        String profileUrl,
+        Gender gender
+) {
+}

--- a/src/main/java/com/fondant/user/presentation/dto/response/UserResponse.java
+++ b/src/main/java/com/fondant/user/presentation/dto/response/UserResponse.java
@@ -1,0 +1,19 @@
+package com.fondant.user.presentation.dto.response;
+
+import com.fondant.user.domain.entity.Gender;
+import lombok.Builder;
+
+import java.sql.Date;
+
+@Builder
+public record UserResponse(
+        String name,
+        String phoneNumber,
+        boolean verifiedPhone,
+        String email,
+        Date birth,
+        String nickname,
+        String profileUrl,
+        Gender gender
+){
+}

--- a/src/test/java/com/fondant/global/annotation/WithMockCustomUser.java
+++ b/src/test/java/com/fondant/global/annotation/WithMockCustomUser.java
@@ -1,0 +1,15 @@
+package com.fondant.global.annotation;
+
+import com.fondant.global.factory.WithMockCustomUserSecurityContextFactory;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+}

--- a/src/test/java/com/fondant/global/factory/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/fondant/global/factory/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,65 @@
+package com.fondant.global.factory;
+
+import com.fondant.infra.jwt.dto.JWTUserDTO;
+import com.fondant.test.repository.UserTestRepository;
+import com.fondant.global.annotation.WithMockCustomUser;
+import com.fondant.user.application.dto.CustomUserDetails;
+import com.fondant.user.domain.entity.Gender;
+import com.fondant.user.domain.entity.SNSType;
+import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.domain.entity.UserRole;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.stereotype.Component;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+@Component
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Autowired
+    private UserTestRepository userRepository;
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        UserEntity user = UserEntity.builder()
+                .name("test")
+                .email("test@example.com")
+                .birth(Date.valueOf(LocalDate.of(2025, 1, 1)))
+                .gender(Gender.MALE)
+                .profileUrl("https://example.com/profile.png")
+                .phoneNumber("010-1234-5678")
+                .verifiedPhone(true)
+                .nickname("tester123")
+                .password("password")
+                .snsType(SNSType.LOCAL)
+                .role(UserRole.USER)
+                .createAt(LocalDate.now())
+                .build();
+
+        user = userRepository.save(user);
+
+        CustomUserDetails userDetails = new CustomUserDetails(
+                JWTUserDTO.builder()
+                        .userId(user.getId())
+                        .userEmail(user.getEmail())
+                        .role(user.getRole().toString())
+                        .build()
+        );
+
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities());
+        context.setAuthentication(auth);
+
+        SecurityContextHolder.setContext(context);
+
+        return context;
+    }
+}

--- a/src/test/java/com/fondant/restdocs/UserRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/UserRestDocsTest.java
@@ -1,0 +1,157 @@
+package com.fondant.restdocs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fondant.global.config.SecurityConfig;
+import com.fondant.infra.jwt.application.JWTUtil;
+import com.fondant.test.repository.UserTestRepository;
+import com.fondant.global.annotation.WithMockCustomUser;
+import com.fondant.user.application.UserService;
+import com.fondant.user.domain.entity.Gender;
+import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.presentation.dto.request.UserUpdateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.Date;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriScheme = "http", uriHost = "localhost", uriPort = 8080)
+@Import(SecurityConfig.class)
+@Transactional
+public class UserRestDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserTestRepository userRepository;
+
+    @Autowired
+    private JWTUtil jwtUtil;
+
+    private static final String BASE_URL = "/api/user";
+
+    public static FieldDescriptor[] commonResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("code").description("요청 성공 여부 (true/false)"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("response").description("응답 데이터")
+        };
+    }
+
+    @BeforeEach
+    public void setUp() {
+    }
+
+    @Test
+    @WithMockCustomUser
+    void getUserInfo() throws Exception {
+
+        mockMvc.perform(get(BASE_URL + "/"))
+                .andExpect(status().isOk())
+                .andDo(document("user/get-user-info",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION)
+                                        .description("Bearer {access-token}")
+                                        .optional(),
+                                headerWithName(HttpHeaders.CONTENT_TYPE)
+                                        .description("application/json")
+                                        .optional()
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
+                                fieldWithPath("name").description("사용자 이름"),
+                                fieldWithPath("phoneNumber").description("전화번호").optional(),
+                                fieldWithPath("verifiedPhone").description("전화번호 인증 여부").optional(),
+                                fieldWithPath("email").description("사용자 이메일"),
+                                fieldWithPath("birth").description("생일").optional(),
+                                fieldWithPath("nickname").description("닉네임").optional(),
+                                fieldWithPath("profileUrl").description("프로필 사진 URL").optional(),
+                                fieldWithPath("gender").description("성별").optional()
+                        })
+                ));
+    }
+
+    @Test
+    @WithMockCustomUser
+    void updateUserInfo() throws Exception {
+
+        UserUpdateRequest request = UserUpdateRequest.builder()
+                .name("updated name")
+                .phoneNumber("010-9999-9999")
+                .verifiedPhone(true)
+                .email("<EMAIL>")
+                .nickname("updated nickname")
+                .profileUrl("https://updated-profile.com/image.jpg")
+                .gender(Gender.FEMALE)
+                .birth(Date.valueOf("2000-01-01"))
+                .build();
+
+        mockMvc.perform(patch(BASE_URL + "/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("user/update-user-info",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("name").description("변경할 사용자 이름").optional(),
+                                fieldWithPath("phoneNumber").description("변경할 전화번호").optional(),
+                                fieldWithPath("verifiedPhone").description("전화번호 인증 여부").optional(),
+                                fieldWithPath("email").description("변경할 이메일").optional(),
+                                fieldWithPath("nickname").description("변경할 닉네임").optional(),
+                                fieldWithPath("profileUrl").description("변경할 프로필 사진 URL").optional(),
+                                fieldWithPath("gender").description("변경할 성별").optional(),
+                                fieldWithPath("birth").description("변경할 생일").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("response").description("응답 데이터")
+                        )
+                ));
+
+        UserEntity updatedUser = userRepository.findByEmail(request.email());
+
+        assertThat(updatedUser.getName()).isEqualTo(request.name());
+        assertThat(updatedUser.getPhoneNumber()).isEqualTo(request.phoneNumber());
+        assertThat(updatedUser.isVerifiedPhone()).isEqualTo(request.verifiedPhone());
+        assertThat(updatedUser.getEmail()).isEqualTo(request.email());
+        assertThat(updatedUser.getNickname()).isEqualTo(request.nickname());
+        assertThat(updatedUser.getPhoneNumber()).isEqualTo(request.phoneNumber());
+        assertThat(updatedUser.getProfileUrl()).isEqualTo(request.profileUrl());
+        assertThat(updatedUser.getGender()).isEqualTo(request.gender());
+    }
+}


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #23 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
간단한 유저 정보 조회 및 수정 기능입니다.

### 1️⃣ 유저 조회 기능 구현
![localhost_63342_ead61b63-b0a6-4ff2-a49a-86be75ccfd1a_source_file=C%3A%2FUsers%2Fleesy%2FIdeaProjects%2FfuncnalProg%2Ffondant-backend%2Fsrc%2Fdocs%2FUserRestDocs adoc mac=2wlAN_eX85iKM0RsOVjGi9_7QQMco4QqGYiEAV4O75w=](https://github.com/user-attachments/assets/dd865164-4fa6-46fd-aa96-d36bf302c9da)

### 2️⃣ 유저 정보 수정 기능 구현
![localhost_63342_ead61b63-b0a6-4ff2-a49a-86be75ccfd1a_source_file=C%3A%2FUsers%2Fleesy%2FIdeaProjects%2FfuncnalProg%2Ffondant-backend%2Fsrc%2Fdocs%2FUserRestDocs adoc mac=2wlAN_eX85iKM0RsOVjGi9_7QQMco4QqGYiEAV4O (1)](https://github.com/user-attachments/assets/fd96a7f0-7ab0-4a49-9423-cc1bd36ffece)

### 3️⃣ Test용 `@WithMockCustomUser` 구현
인증 과정을 뛰어넘고 나서 Mock사용자를 만들어 사용하기 위해 `@WithSecurityContext`과 WithSecurityContextFactory를 커스텀해 적용하였습니다.
## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
테스트 할때 MockUser 사용해서 진행했더니 테스트코드에서 헤더를 못넣네요,, 그래서 restdocs에 직접 써줬는데
혹시 더 나은 방법이 있다면,, 훈수 부탁 드리겠습니다
+) Factory 내부에서 유저정보를 꺼내 토큰을 생성한다면 할 수 있지 않을까 라는 생각이 났는데 일단 기능부터 구현하고 리팩토링할 때 해보겠습니다.