### PR TITLE
[Feat] 마켓 인기순 조회 구현

### DIFF
--- a/src/docs/MarketRestDocs.adoc
+++ b/src/docs/MarketRestDocs.adoc
@@ -46,3 +46,21 @@ include::{snippets}/markets/get-market-by-id/http-response.adoc[]
 ==== response body
 
 include::{snippets}/markets/get-market-by-id/response-fields.adoc[]
+
+=== 3. 종합 인기 Top10 마켓 목록 조회
+
+==== HTTP request
+
+include::{snippets}/markets/get-top10-markets-by-popularity/http-request.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/markets/get-top10-markets-by-popularity/query-parameters.adoc[]
+
+==== HTTP response
+
+include::{snippets}/markets/get-top10-markets-by-popularity/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/markets/get-top10-markets-by-popularity/response-fields.adoc[]

--- a/src/docs/MarketRestDocs.adoc
+++ b/src/docs/MarketRestDocs.adoc
@@ -80,4 +80,21 @@ include::{snippets}/markets/get-top30-markets-by-category/query-parameters.adoc[
 include::{snippets}/markets/get-top30-markets-by-category/http-response.adoc[]
 
 ==== response body
-include::{snippets}/markets/get-top30-markets-by-category/response-body.adoc[]
+include::{snippets}/markets/get-top30-markets-by-category/response-fields.adoc[]
+
+=== 5. 카테고리별 랜덤 인기 Top5 마켓 목록 조회
+
+==== HTTP request
+include::{snippets}/markets/get-random-top5-markets-by-category/http-request.adoc[]
+
+==== Path Parameters
+include::{snippets}/markets/get-random-top5-markets-by-category/path-parameters.adoc[]
+
+==== Query Parameters
+include::{snippets}/markets/get-random-top5-markets-by-category/query-parameters.adoc[]
+
+==== HTTP response
+include::{snippets}/markets/get-random-top5-markets-by-category/http-response.adoc[]
+
+==== response body
+include::{snippets}/markets/get-random-top5-markets-by-category/response-fields.adoc[]

--- a/src/docs/MarketRestDocs.adoc
+++ b/src/docs/MarketRestDocs.adoc
@@ -64,3 +64,20 @@ include::{snippets}/markets/get-top10-markets-by-popularity/http-response.adoc[]
 ==== response body
 
 include::{snippets}/markets/get-top10-markets-by-popularity/response-fields.adoc[]
+
+=== 4. 카테고리별 인기 Top30 마켓 목록 조회
+
+==== HTTP request
+include::{snippets}/markets/get-top30-markets-by-category/http-request.adoc[]
+
+==== Path Parameters
+include::{snippets}/markets/get-top30-markets-by-category/path-parameters.adoc[]
+
+==== Query Parameters
+include::{snippets}/markets/get-top30-markets-by-category/query-parameters.adoc[]
+
+==== HTTP response
+include::{snippets}/markets/get-top30-markets-by-category/http-response.adoc[]
+
+==== response body
+include::{snippets}/markets/get-top30-markets-by-category/response-body.adoc[]

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -54,6 +55,19 @@ public class MarketService {
         return convertToDetailDto(market);
     }
 
+    @Transactional(readOnly = true)
+    public List<MarketsResponse> getTop10MarketsByPopularity() {
+        List<MarketEntity> markets = marketRepository.findTop10MarketsByPopularity();
+
+        if (markets == null || markets.isEmpty()) {
+            throw new ApiException(MarketError.NO_MARKETS_FOUND);
+        }
+
+        return List.of(MarketsResponse.builder()
+                .markets(convertToMarketInfos(markets))
+                .build());
+    }
+
     private List<MarketInfo> getMarketInfos(List<MarketEntity> markets) {
         return markets.stream()
                 .map(market -> MarketInfo.builder()
@@ -73,5 +87,16 @@ public class MarketService {
                 .thumbnail(market.getThumbnail())
                 .background(market.getBackground())
                 .build();
+    }
+
+    private List<MarketInfo> convertToMarketInfos(List<MarketEntity> markets) {
+        return markets.stream()
+                .map(market -> MarketInfo.builder()
+                        .id(market.getId())
+                        .name(market.getName())
+                        .description(market.getDescription())
+                        .thumbnail(market.getThumbnail())
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -70,13 +70,17 @@ public class MarketService {
     }
 
     @Transactional(readOnly = true)
-    public MarketsResponse getTop5MarketsByPopularity() {
-        List<MarketEntity> markets = marketRepository.findTop5MarketsByPopularity();
+    public MarketsResponse getRandomTop5MarketsByCategoryId(Long categoryId, Pageable pageable) {
+        Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
+        Page<MarketEntity> markets = marketRepository.findRandomTop5MarketsByCategory(categoryId, effectivePageable);
+
         if (markets == null || markets.isEmpty()) {
             throw new ApiException(MarketError.NO_MARKETS_FOUND);
         }
+
         return MarketsResponse.builder()
-                .markets(convertToMarketInfos(markets))
+                .pageInfo(PageInfo.of(markets.getNumber(), markets.getTotalPages()))
+                .markets(getMarketInfos(markets.getContent()))
                 .build();
     }
 

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -66,6 +65,28 @@ public class MarketService {
         return List.of(MarketsResponse.builder()
                 .markets(convertToMarketInfos(markets))
                 .build());
+    }
+
+    @Transactional(readOnly = true)
+    public MarketsResponse getTop5MarketsByPopularity() {
+        List<MarketEntity> markets = marketRepository.findTop5MarketsByPopularity();
+        if (markets == null || markets.isEmpty()) {
+            throw new ApiException(MarketError.NO_MARKETS_FOUND);
+        }
+        return MarketsResponse.builder()
+                .markets(convertToMarketInfos(markets))
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public MarketsResponse getTop30MarketsByPopularity() {
+        List<MarketEntity> markets = marketRepository.findTop30MarketsByPopularity();
+        if (markets == null || markets.isEmpty()) {
+            throw new ApiException(MarketError.NO_MARKETS_FOUND);
+        }
+        return MarketsResponse.builder()
+                .markets(convertToMarketInfos(markets))
+                .build();
     }
 
     private List<MarketInfo> getMarketInfos(List<MarketEntity> markets) {

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -81,13 +81,17 @@ public class MarketService {
     }
 
     @Transactional(readOnly = true)
-    public MarketsResponse getTop30MarketsByPopularity() {
-        List<MarketEntity> markets = marketRepository.findTop30MarketsByPopularity();
-        if (markets == null || markets.isEmpty()) {
-            throw new ApiException(MarketError.NO_MARKETS_FOUND);
+    public MarketsResponse getTop30MarketsByCategoryId(Long categoryId, Pageable pageable) {
+        if (categoryId == null || categoryId <= 0) {
+            throw new ApiException(MarketError.INVALID_CATEGORY_ID);
         }
+
+        Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
+        Page<MarketEntity> markets = marketRepository.findTop30MarketsByCategory(categoryId, effectivePageable);
+
         return MarketsResponse.builder()
-                .markets(convertToMarketInfos(markets))
+                .pageInfo(PageInfo.of(markets.getNumber(), markets.getTotalPages()))
+                .markets(getMarketInfos(markets.getContent()))
                 .build();
     }
 

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -96,6 +96,8 @@ public class MarketService {
                         .name(market.getName())
                         .description(market.getDescription())
                         .thumbnail(market.getThumbnail())
+                        .totalReviews(market.getTotalReviews())
+                        .totalSales(market.getTotalSales())
                         .build())
                 .toList();
     }
@@ -117,6 +119,8 @@ public class MarketService {
                         .name(market.getName())
                         .description(market.getDescription())
                         .thumbnail(market.getThumbnail())
+                        .totalSales(market.getTotalSales())
+                        .totalReviews(market.getTotalReviews())
                         .build())
                 .toList();
     }

--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -55,16 +55,18 @@ public class MarketService {
     }
 
     @Transactional(readOnly = true)
-    public List<MarketsResponse> getTop10MarketsByPopularity() {
-        List<MarketEntity> markets = marketRepository.findTop10MarketsByPopularity();
+    public MarketsResponse getTop10MarketsByPopularity(Pageable pageable) {
+        Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
+        Page<MarketEntity> markets = marketRepository.findTop10MarketsByPopularity(effectivePageable);
 
         if (markets == null || markets.isEmpty()) {
             throw new ApiException(MarketError.NO_MARKETS_FOUND);
         }
 
-        return List.of(MarketsResponse.builder()
-                .markets(convertToMarketInfos(markets))
-                .build());
+        return MarketsResponse.builder()
+                .pageInfo(PageInfo.of(markets.getNumber(), markets.getTotalPages()))
+                .markets(getMarketInfos(markets.getContent()))
+                .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
+++ b/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
@@ -49,24 +49,25 @@ public class MarketEntity {
 
     @NotNull
     @Column(name="delivery_fee", nullable = false)
-    private long deliveryFee;
+    private Long deliveryFee;
 
     @NotNull
     @Column(name="free_delivery_limit", nullable = false)
-    private long freeDeliveryLimit;
+    private Long freeDeliveryLimit;
 
     @Builder
-    MarketEntity(String name, Long totalSales, Long totalReviews, LocalDate createAt, LocalDate updateAt, String description, String thumbnail, String background, long deliveryFee, long freeDeliveryLimit) {
+    public MarketEntity(String name, Long totalSales, Long totalReviews, LocalDate createAt, LocalDate updateAt,
+                        String description, String thumbnail, String background, Long deliveryFee, Long freeDeliveryLimit) {
         this.name = name;
-        this.totalSales = 0L;
-        this.totalReviews = 0L;
-        this.createAt = LocalDate.now();
+        this.totalSales = totalSales != null ? totalSales : 0L;
+        this.totalReviews = totalReviews != null ? totalReviews : 0L;
+        this.createAt = createAt != null ? createAt : LocalDate.now();
         this.updateAt = updateAt;
         this.description = description;
         this.thumbnail = thumbnail;
         this.background = background;
-        this.deliveryFee = 0L;
-        this.freeDeliveryLimit = 0L;
+        this.deliveryFee = deliveryFee != null ? deliveryFee : 0L;
+        this.freeDeliveryLimit = freeDeliveryLimit != null ? freeDeliveryLimit : 0L;
     }
 
 }

--- a/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
+++ b/src/main/java/com/fondant/market/domain/entity/MarketEntity.java
@@ -51,8 +51,12 @@ public class MarketEntity {
     @Column(name="delivery_fee", nullable = false)
     private long deliveryFee;
 
+    @NotNull
+    @Column(name="free_delivery_limit", nullable = false)
+    private long freeDeliveryLimit;
+
     @Builder
-    MarketEntity(String name, Long totalSales, Long totalReviews, LocalDate createAt, LocalDate updateAt, String description, String thumbnail, String background, long deliveryFee) {
+    MarketEntity(String name, Long totalSales, Long totalReviews, LocalDate createAt, LocalDate updateAt, String description, String thumbnail, String background, long deliveryFee, long freeDeliveryLimit) {
         this.name = name;
         this.totalSales = 0L;
         this.totalReviews = 0L;
@@ -62,6 +66,7 @@ public class MarketEntity {
         this.thumbnail = thumbnail;
         this.background = background;
         this.deliveryFee = 0L;
+        this.freeDeliveryLimit = 0L;
     }
 
 }

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepository.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepository.java
@@ -4,4 +4,5 @@ import com.fondant.market.domain.entity.MarketEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MarketRepository extends JpaRepository<MarketEntity, Long>,MarketRepositoryCustom {
+
 }

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
@@ -9,7 +9,8 @@ import java.util.List;
 
 public interface MarketRepositoryCustom {
     Page<MarketEntity> findMarketsByCategory(Long categoryId, Pageable pageable);
-    List<MarketEntity> findTop10MarketsByPopularity();
+
+    Page<MarketEntity> findTop10MarketsByPopularity(Pageable pageable);
 
     List<MarketEntity> findTop5MarketsByPopularity();
 

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
@@ -5,6 +5,9 @@ import com.fondant.market.domain.entity.MarketEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface MarketRepositoryCustom {
     Page<MarketEntity> findMarketsByCategory(Long categoryId, Pageable pageable);
+    List<MarketEntity> findTop10MarketsByPopularity();
 }

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
@@ -12,7 +12,7 @@ public interface MarketRepositoryCustom {
 
     Page<MarketEntity> findTop10MarketsByPopularity(Pageable pageable);
 
-    List<MarketEntity> findTop5MarketsByPopularity();
+    Page<MarketEntity> findRandomTop5MarketsByCategory(Long categoryId, Pageable pageable);
 
     Page<MarketEntity> findTop30MarketsByCategory(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
@@ -10,4 +10,8 @@ import java.util.List;
 public interface MarketRepositoryCustom {
     Page<MarketEntity> findMarketsByCategory(Long categoryId, Pageable pageable);
     List<MarketEntity> findTop10MarketsByPopularity();
+
+    List<MarketEntity> findTop5MarketsByPopularity();
+
+    List<MarketEntity> findTop30MarketsByPopularity();
 }

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryCustom.java
@@ -14,5 +14,5 @@ public interface MarketRepositoryCustom {
 
     List<MarketEntity> findTop5MarketsByPopularity();
 
-    List<MarketEntity> findTop30MarketsByPopularity();
+    Page<MarketEntity> findTop30MarketsByCategory(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -1,10 +1,16 @@
 package com.fondant.market.domain.repository;
 
+import com.fondant.global.exception.ApiException;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.market.domain.entity.QMarketCategoryEntity;
 import com.fondant.market.domain.entity.QMarketEntity;
+import com.fondant.market.exception.MarketError;
 import com.fondant.product.domain.entity.QCategoryEntity;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +20,9 @@ import java.util.List;
 public class MarketRepositoryImpl implements MarketRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     public MarketRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
@@ -44,5 +53,28 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public List<MarketEntity> findTop10MarketsByPopularity() {
+        QMarketEntity market = QMarketEntity.marketEntity;
+
+        NumberExpression<Double> popularityScore = market.totalSales
+                .coalesce(0L).castToNum(Double.class)
+                .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
+                .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
+
+        List<MarketEntity> markets = queryFactory
+                .selectFrom(market)
+                .where(market.createAt.isNotNull())
+                .orderBy(popularityScore.desc())
+                .limit(10)
+                .fetch();
+
+        if (markets.isEmpty()) {
+            throw new ApiException(MarketError.NO_MARKETS_FOUND);
+        }
+
+        return markets;
     }
 }

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -15,7 +15,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class MarketRepositoryImpl implements MarketRepositoryCustom {
 
@@ -69,6 +71,49 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 .where(market.createAt.isNotNull())
                 .orderBy(popularityScore.desc())
                 .limit(10)
+                .fetch();
+
+        if (markets.isEmpty()) {
+            throw new ApiException(MarketError.NO_MARKETS_FOUND);
+        }
+
+        return markets;
+    }
+
+    @Override
+    public List<MarketEntity> findTop5MarketsByPopularity() {
+        QMarketEntity market = QMarketEntity.marketEntity;
+
+        NumberExpression<Double> popularityScore = market.totalSales
+                .coalesce(0L).castToNum(Double.class)
+                .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
+                .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
+
+        List<MarketEntity> markets = queryFactory
+                .selectFrom(market)
+                .where(market.createAt.isNotNull())
+                .orderBy(popularityScore.desc())
+                .limit(30)
+                .fetch();
+
+        Collections.shuffle(markets);
+        return markets.stream().limit(5).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<MarketEntity> findTop30MarketsByPopularity() {
+        QMarketEntity market = QMarketEntity.marketEntity;
+
+        NumberExpression<Double> popularityScore = market.totalSales
+                .coalesce(0L).castToNum(Double.class)
+                .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
+                .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
+
+        List<MarketEntity> markets = queryFactory
+                .selectFrom(market)
+                .where(market.createAt.isNotNull())
+                .orderBy(popularityScore.desc())
+                .limit(30)
                 .fetch();
 
         if (markets.isEmpty()) {

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -81,8 +81,10 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
     }
 
     @Override
-    public List<MarketEntity> findTop5MarketsByPopularity() {
+    public Page<MarketEntity> findRandomTop5MarketsByCategory(Long categoryId, Pageable pageable) {
         QMarketEntity market = QMarketEntity.marketEntity;
+        QMarketCategoryEntity marketCategory = QMarketCategoryEntity.marketCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
 
         NumberExpression<Double> popularityScore = market.totalSales
                 .coalesce(0L).castToNum(Double.class)
@@ -91,8 +93,13 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
 
         JPQLQuery<Long> subQuery = JPAExpressions
                 .select(market.id)
-                .from(market)
-                .where(market.createAt.isNotNull())
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(
+                        category.id.eq(categoryId)
+                                .and(market.createAt.isNotNull())
+                )
                 .orderBy(popularityScore.desc())
                 .limit(30);
 
@@ -103,7 +110,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 .limit(5)
                 .fetch();
 
-        return markets;
+        return new PageImpl<>(markets, pageable, markets.size());
     }
 
     @Override

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -107,8 +107,10 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
     }
 
     @Override
-    public List<MarketEntity> findTop30MarketsByPopularity() {
+    public Page<MarketEntity> findTop30MarketsByCategory(Long categoryId, Pageable pageable) {
         QMarketEntity market = QMarketEntity.marketEntity;
+        QMarketCategoryEntity marketCategory = QMarketCategoryEntity.marketCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
 
         NumberExpression<Double> popularityScore = market.totalSales
                 .coalesce(0L).castToNum(Double.class)
@@ -116,8 +118,23 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
 
         List<MarketEntity> markets = queryFactory
-                .selectFrom(market)
-                .where(market.createAt.isNotNull())
+                .select(market)
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(
+                        category.id.eq(categoryId)
+                                .and(market.createAt.isNotNull())
+                )
+                .groupBy(
+                        market.id,
+                        market.createAt,
+                        market.description,
+                        market.name,
+                        market.thumbnail,
+                        market.totalReviews,
+                        market.totalSales
+                )
                 .orderBy(popularityScore.desc())
                 .limit(30)
                 .fetch();
@@ -126,6 +143,17 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
             throw new ApiException(MarketError.NO_MARKETS_FOUND);
         }
 
-        return markets;
+        long total = queryFactory
+                .select(market.countDistinct())
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(
+                        category.id.eq(categoryId)
+                                .and(market.createAt.isNotNull())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(markets, pageable, total);
     }
 }

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -8,6 +8,8 @@ import com.fondant.market.exception.MarketError;
 import com.fondant.product.domain.entity.QCategoryEntity;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -15,9 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class MarketRepositoryImpl implements MarketRepositoryCustom {
 
@@ -89,15 +89,21 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
                 .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
 
-        List<MarketEntity> markets = queryFactory
-                .selectFrom(market)
+        JPQLQuery<Long> subQuery = JPAExpressions
+                .select(market.id)
+                .from(market)
                 .where(market.createAt.isNotNull())
                 .orderBy(popularityScore.desc())
-                .limit(30)
+                .limit(30);
+
+        List<MarketEntity> markets = queryFactory
+                .selectFrom(market)
+                .where(market.id.in(subQuery))
+                .orderBy(Expressions.numberTemplate(Double.class, "random()").asc())
+                .limit(5)
                 .fetch();
 
-        Collections.shuffle(markets);
-        return markets.stream().limit(5).collect(Collectors.toList());
+        return markets;
     }
 
     @Override

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -58,7 +58,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
     }
 
     @Override
-    public List<MarketEntity> findTop10MarketsByPopularity() {
+    public Page<MarketEntity> findTop10MarketsByPopularity(Pageable pageable) {
         QMarketEntity market = QMarketEntity.marketEntity;
 
         NumberExpression<Double> popularityScore = market.totalSales
@@ -77,7 +77,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
             throw new ApiException(MarketError.NO_MARKETS_FOUND);
         }
 
-        return markets;
+        return new PageImpl<>(markets, pageable, markets.size());
     }
 
     @Override

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -124,7 +124,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
                 .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
 
-        List<MarketEntity> markets = queryFactory
+        List<MarketEntity> top30Markets = queryFactory
                 .select(market)
                 .from(marketCategory)
                 .join(marketCategory.market, market)
@@ -146,11 +146,11 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 .limit(30)
                 .fetch();
 
-        if (markets.isEmpty()) {
+        if (top30Markets.isEmpty()) {
             throw new ApiException(MarketError.NO_MARKETS_FOUND);
         }
 
-        long total = queryFactory
+        long rawTotal = queryFactory
                 .select(market.countDistinct())
                 .from(marketCategory)
                 .join(marketCategory.market, market)
@@ -161,6 +161,14 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
                 )
                 .fetchOne();
 
-        return new PageImpl<>(markets, pageable, total);
+        long total = Math.min(rawTotal, 30);
+
+        int totalInt = (int) total;
+        int offset = (int) pageable.getOffset();
+        int pageSize = pageable.getPageSize();
+        int end = Math.min(offset + pageSize, totalInt);
+        List<MarketEntity> pageContent = top30Markets.subList(offset, end);
+
+        return new PageImpl<>(pageContent, pageable, total);
     }
 }

--- a/src/main/java/com/fondant/market/exception/MarketError.java
+++ b/src/main/java/com/fondant/market/exception/MarketError.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum MarketError implements ErrorCode {
     MARKET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마켓을 찾을 수 없습니다.", "MARKET_NOT_FOUND"),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다.", "CATEGORY_NOT_FOUND"),
-    NO_MARKETS_FOUND(HttpStatus.NO_CONTENT, "해당 카테고리에 등록된 마켓이 없습니다.", "NO_MARKETS_FOUND"),
+    NO_MARKETS_FOUND(HttpStatus.NO_CONTENT, "등록된 마켓이 없습니다.", "NO_MARKETS_FOUND"),
     INVALID_MARKET_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 marketId입니다.", "INVALID_MARKET_ID"),
     INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 categoryId입니다.", "INVALID_CATEGORY_ID"),
     INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다.", "INVALID_PAGE_NUMBER");

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/markets")
@@ -34,5 +36,10 @@ public class MarketController {
 
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
                 marketService.getMarketsByCategoryId(categoryId, effectivePageable)));
+    }
+
+    @GetMapping("/top10")
+    public ResponseEntity<List<MarketsResponse>> getTop10MarketsByPopularity() {
+        return ResponseEntity.ok(marketService.getTop10MarketsByPopularity());
     }
 }

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -42,4 +42,14 @@ public class MarketController {
     public ResponseEntity<List<MarketsResponse>> getTop10MarketsByPopularity() {
         return ResponseEntity.ok(marketService.getTop10MarketsByPopularity());
     }
+
+    @GetMapping("/top5")
+    public ResponseEntity<MarketsResponse> getTop5MarketsByPopularity() {
+        return ResponseEntity.ok(marketService.getTop5MarketsByPopularity());
+    }
+
+    @GetMapping("/top30")
+    public ResponseEntity<MarketsResponse> getTop30MarketsByPopularity() {
+        return ResponseEntity.ok(marketService.getTop30MarketsByPopularity());
+    }
 }

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -39,8 +39,13 @@ public class MarketController {
     }
 
     @GetMapping("/top10")
-    public ResponseEntity<List<MarketsResponse>> getTop10MarketsByPopularity() {
-        return ResponseEntity.ok(marketService.getTop10MarketsByPopularity());
+    public ResponseEntity<ResponseDto<MarketsResponse>> getTop10MarketsByPopularity(
+            @RequestParam(required = false) Pageable pageable) {
+
+        Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
+
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                marketService.getTop10MarketsByPopularity(effectivePageable)));
     }
 
     @GetMapping("/top5")

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -11,8 +11,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/markets")
@@ -53,8 +51,14 @@ public class MarketController {
         return ResponseEntity.ok(marketService.getTop5MarketsByPopularity());
     }
 
-    @GetMapping("/top30")
-    public ResponseEntity<MarketsResponse> getTop30MarketsByPopularity() {
-        return ResponseEntity.ok(marketService.getTop30MarketsByPopularity());
+    @GetMapping("/{categoryId}/top30")
+    public ResponseEntity<ResponseDto<MarketsResponse>> getTop30MarketsByPopularity(
+            @PathVariable(name = "categoryId") Long categoryId,
+            @RequestParam(required = false) Pageable pageable) {
+
+        Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
+        MarketsResponse marketsResponse = marketService.getTop30MarketsByCategoryId(categoryId, effectivePageable);
+
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, marketsResponse));
     }
 }

--- a/src/main/java/com/fondant/market/presentation/MarketController.java
+++ b/src/main/java/com/fondant/market/presentation/MarketController.java
@@ -46,9 +46,15 @@ public class MarketController {
                 marketService.getTop10MarketsByPopularity(effectivePageable)));
     }
 
-    @GetMapping("/top5")
-    public ResponseEntity<MarketsResponse> getTop5MarketsByPopularity() {
-        return ResponseEntity.ok(marketService.getTop5MarketsByPopularity());
+    @GetMapping("/{categoryId}/top5")
+    public ResponseEntity<ResponseDto<MarketsResponse>> getRandomTop5MarketsByCategoryId(
+            @PathVariable(name = "categoryId") Long categoryId,
+            @RequestParam(required = false) Pageable pageable) {
+
+        Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
+        MarketsResponse marketsResponse = marketService.getRandomTop5MarketsByCategoryId(categoryId, effectivePageable);
+
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, marketsResponse));
     }
 
     @GetMapping("/{categoryId}/top30")

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -226,4 +226,35 @@ public class MarketRestDocsTest {
                                 fieldWithPath("markets[].totalReviews").description("총 리뷰 개수")
                         })));
     }
+
+    @Test
+    void getRandomTop5MarketsByCategory() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/{categoryId}/top5", category2.getId())
+                        .param("page", "0")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("markets/get-random-top5-markets-by-category",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("categoryId").description("조회할 카테고리 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)")
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
+                                fieldWithPath("pageInfo").description("페이지 정보"),
+                                fieldWithPath("pageInfo.currentPage").description("현재 페이지"),
+                                fieldWithPath("pageInfo.totalPage").description("전체 페이지"),
+                                fieldWithPath("markets").description("마켓 목록"),
+                                fieldWithPath("markets[].id").description("마켓 ID"),
+                                fieldWithPath("markets[].name").description("마켓 이름"),
+                                fieldWithPath("markets[].description").description("마켓 한줄 소개"),
+                                fieldWithPath("markets[].thumbnail").description("마켓 썸네일 이미지 URL"),
+                                fieldWithPath("markets[].totalSales").description("총 판매 수량"),
+                                fieldWithPath("markets[].totalReviews").description("총 리뷰 개수")
+                        })));
+    }
 }

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -17,9 +17,6 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.List;
-
-import static com.fondant.restdocs.ProductRestDocsTest.commonResponseFields;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -49,7 +46,9 @@ public class MarketRestDocsTest {
 
     private MarketEntity market1;
     private MarketEntity market2;
-    private CategoryEntity category;
+    private MarketEntity market3;
+    private CategoryEntity category1;
+    private CategoryEntity category2;
 
     private static final String BASE_URL = "/api/markets";
 
@@ -59,36 +58,54 @@ public class MarketRestDocsTest {
         categoryRepository.deleteAll();
         marketRepository.deleteAll();
         
-        category = categoryRepository.save(CategoryEntity.builder()
+        category1 = categoryRepository.save(CategoryEntity.builder()
                 .name("쿠키")
                 .build());
 
+        category2 = categoryRepository.save(CategoryEntity.builder()
+                .name("빵")
+                .build());
+
         market1 = marketRepository.save(MarketEntity.builder()
-                .name("Market A")
-                .description("쿠키를 판매하는 마켓 A")
+                .name("상윤이네 쿠키")
+                .description("쿠키를 판매하는 마켓")
                 .thumbnail("market-a-thumbnail.jpg")
                 .background("market-a-bg.jpg")
-                .totalSales(50L)
+                .totalSales(500L)
                 .totalReviews(100L)
                 .build());
 
         market2 = marketRepository.save(MarketEntity.builder()
-                .name("Market B")
-                .description("쿠키를 판매하는 마켓 B")
+                .name("명인 강지원")
+                .description("쿠키를 판매하는 마켓")
                 .thumbnail("market-b-thumbnail.jpg")
                 .background("market-b-bg.jpg")
-                .totalSales(50L)
-                .totalReviews(2000L)
+                .totalSales(500L)
+                .totalReviews(200L)
+                .build());
+
+        market3 = marketRepository.save(MarketEntity.builder()
+                .name("도현베이커리")
+                .description("빵을 판매하는 마켓")
+                .thumbnail("market-b-thumbnail.jpg")
+                .background("market-b-bg.jpg")
+                .totalSales(100L)
+                .totalReviews(70L)
                 .build());
 
         marketCategoryRepository.save(MarketCategoryEntity.builder()
                 .market(market1)
-                .category(category)
+                .category(category1)
                 .build());
 
         marketCategoryRepository.save(MarketCategoryEntity.builder()
                 .market(market2)
-                .category(category)
+                .category(category1)
+                .build());
+
+        marketCategoryRepository.save(MarketCategoryEntity.builder()
+                .market(market3)
+                .category(category2)
                 .build());
     }
     public static FieldDescriptor[] commonResponseFields() {
@@ -101,7 +118,7 @@ public class MarketRestDocsTest {
 
     @Test
     void getMarketsByCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/categories/{categoryId}", category.getId())
+        mockMvc.perform(get(BASE_URL + "/categories/{categoryId}", category2.getId())
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -160,6 +177,37 @@ public class MarketRestDocsTest {
                 .andDo(document("markets/get-top10-markets-by-popularity",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)")
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
+                                fieldWithPath("pageInfo").description("페이지 정보"),
+                                fieldWithPath("pageInfo.currentPage").description("현재 페이지"),
+                                fieldWithPath("pageInfo.totalPage").description("전체 페이지"),
+                                fieldWithPath("markets").description("마켓 목록"),
+                                fieldWithPath("markets[].id").description("마켓 ID"),
+                                fieldWithPath("markets[].name").description("마켓 이름"),
+                                fieldWithPath("markets[].description").description("마켓 한줄 소개"),
+                                fieldWithPath("markets[].thumbnail").description("마켓 썸네일 이미지 URL"),
+                                fieldWithPath("markets[].totalSales").description("총 판매 수량"),
+                                fieldWithPath("markets[].totalReviews").description("총 리뷰 개수")
+                        })));
+    }
+
+    @Test
+    void getTop30MarketsByCategory() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/{categoryId}/top30", category1.getId())
+                .param("page", "0")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("markets/get-top30-markets-by-category",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("categoryId").description("조회할 카테고리 ID")
+                        ),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0부터 시작)")
                         ),

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -17,6 +17,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.Arrays;
+
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -44,11 +46,9 @@ public class MarketRestDocsTest {
     @Autowired
     private MarketCategoryTestRepository marketCategoryRepository;
 
-    private MarketEntity market1;
-    private MarketEntity market2;
-    private MarketEntity market3;
-    private CategoryEntity category1;
-    private CategoryEntity category2;
+    private CategoryEntity categoryCookie;
+    private CategoryEntity categoryBread;
+    private CategoryEntity categoryBakedGoods;
 
     private static final String BASE_URL = "/api/markets";
 
@@ -57,57 +57,44 @@ public class MarketRestDocsTest {
         marketCategoryRepository.deleteAll();
         categoryRepository.deleteAll();
         marketRepository.deleteAll();
-        
-        category1 = categoryRepository.save(CategoryEntity.builder()
-                .name("쿠키")
-                .build());
 
-        category2 = categoryRepository.save(CategoryEntity.builder()
-                .name("빵")
-                .build());
+        categoryCookie = categoryRepository.save(
+                CategoryEntity.builder().name("쿠키").build());
+        categoryBread = categoryRepository.save(
+                CategoryEntity.builder().name("빵").build());
+        categoryBakedGoods = categoryRepository.save(
+                CategoryEntity.builder().name("구움과자").build());
 
-        market1 = marketRepository.save(MarketEntity.builder()
-                .name("상윤이네 쿠키")
-                .description("쿠키를 판매하는 마켓")
-                .thumbnail("market-a-thumbnail.jpg")
-                .background("market-a-bg.jpg")
-                .totalSales(500L)
-                .totalReviews(100L)
-                .build());
+        int marketCount = 1;
+        for (CategoryEntity category : Arrays.asList(categoryCookie, categoryBread, categoryBakedGoods)) {
+            String categoryName;
+            if (category == categoryCookie) {
+                categoryName = "쿠키";
+            } else if (category == categoryBread) {
+                categoryName = "빵";
+            } else {
+                categoryName = "구움과자";
+            }
 
-        market2 = marketRepository.save(MarketEntity.builder()
-                .name("명인 강지원")
-                .description("쿠키를 판매하는 마켓")
-                .thumbnail("market-b-thumbnail.jpg")
-                .background("market-b-bg.jpg")
-                .totalSales(500L)
-                .totalReviews(200L)
-                .build());
+            for (int i = 1; i <= 40; i++) {
+                MarketEntity market = marketRepository.save(MarketEntity.builder()
+                        .name("마켓 " + marketCount)
+                        .description(categoryName + "을 판매하는 마켓 " + marketCount)
+                        .thumbnail("market-" + marketCount + "-thumbnail.jpg")
+                        .background("market-" + marketCount + "-bg.jpg")
+                        .totalSales(100L * marketCount)
+                        .totalReviews(10L * marketCount)
+                        .build());
 
-        market3 = marketRepository.save(MarketEntity.builder()
-                .name("도현베이커리")
-                .description("빵을 판매하는 마켓")
-                .thumbnail("market-b-thumbnail.jpg")
-                .background("market-b-bg.jpg")
-                .totalSales(100L)
-                .totalReviews(70L)
-                .build());
-
-        marketCategoryRepository.save(MarketCategoryEntity.builder()
-                .market(market1)
-                .category(category1)
-                .build());
-
-        marketCategoryRepository.save(MarketCategoryEntity.builder()
-                .market(market2)
-                .category(category1)
-                .build());
-
-        marketCategoryRepository.save(MarketCategoryEntity.builder()
-                .market(market3)
-                .category(category2)
-                .build());
+                marketCategoryRepository.save(MarketCategoryEntity.builder()
+                        .market(market)
+                        .category(category)
+                        .build());
+                marketCount++;
+            }
+        }
     }
+
     public static FieldDescriptor[] commonResponseFields() {
         return new FieldDescriptor[]{
                 fieldWithPath("code").description("요청 성공 여부 (true/false)"),
@@ -118,7 +105,7 @@ public class MarketRestDocsTest {
 
     @Test
     void getMarketsByCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/categories/{categoryId}", category2.getId())
+        mockMvc.perform(get(BASE_URL + "/categories/{categoryId}", categoryBread.getId())
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -148,7 +135,8 @@ public class MarketRestDocsTest {
 
     @Test
     void getMarketById() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/{marketId}", market1.getId())
+        MarketEntity market = marketRepository.findAll().get(0);
+        mockMvc.perform(get(BASE_URL + "/{marketId}", market.getId())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(document("markets/get-market-by-id",
@@ -198,7 +186,7 @@ public class MarketRestDocsTest {
 
     @Test
     void getTop30MarketsByCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/{categoryId}/top30", category1.getId())
+        mockMvc.perform(get(BASE_URL + "/{categoryId}/top30", categoryCookie.getId())
                 .param("page", "0")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -229,7 +217,7 @@ public class MarketRestDocsTest {
 
     @Test
     void getRandomTop5MarketsByCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/{categoryId}/top5", category2.getId())
+        mockMvc.perform(get(BASE_URL + "/{categoryId}/top5", categoryCookie.getId())
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -17,6 +17,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
+
 import static com.fondant.restdocs.ProductRestDocsTest.commonResponseFields;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -24,6 +26,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -52,6 +55,10 @@ public class MarketRestDocsTest {
 
     @BeforeEach
     void setUp() {
+        marketCategoryRepository.deleteAll();
+        categoryRepository.deleteAll();
+        marketRepository.deleteAll();
+        
         category = categoryRepository.save(CategoryEntity.builder()
                 .name("쿠키")
                 .build());
@@ -61,6 +68,8 @@ public class MarketRestDocsTest {
                 .description("쿠키를 판매하는 마켓 A")
                 .thumbnail("market-a-thumbnail.jpg")
                 .background("market-a-bg.jpg")
+                .totalSales(50L)
+                .totalReviews(100L)
                 .build());
 
         market2 = marketRepository.save(MarketEntity.builder()
@@ -68,6 +77,8 @@ public class MarketRestDocsTest {
                 .description("쿠키를 판매하는 마켓 B")
                 .thumbnail("market-b-thumbnail.jpg")
                 .background("market-b-bg.jpg")
+                .totalSales(50L)
+                .totalReviews(2000L)
                 .build());
 
         marketCategoryRepository.save(MarketCategoryEntity.builder()
@@ -79,6 +90,13 @@ public class MarketRestDocsTest {
                 .market(market2)
                 .category(category)
                 .build());
+    }
+    public static FieldDescriptor[] commonResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("code").description("요청 성공 여부 (true/false)"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("response").description("응답 데이터")
+        };
     }
 
     @Test
@@ -130,6 +148,34 @@ public class MarketRestDocsTest {
                                 fieldWithPath("description").description("마켓 한줄 소개"),
                                 fieldWithPath("thumbnail").description("마켓 썸네일 이미지 URL"),
                                 fieldWithPath("background").description("마켓 배경 이미지 URL")
+                        })));
+    }
+
+    @Test
+    void getTop10MarketsByPopularity() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/top10")
+                        .param("page", "0")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("markets/get-top10-markets-by-popularity",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)")
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
+                                fieldWithPath("pageInfo").description("페이지 정보"),
+                                fieldWithPath("pageInfo.currentPage").description("현재 페이지"),
+                                fieldWithPath("pageInfo.totalPage").description("전체 페이지"),
+                                fieldWithPath("markets").description("마켓 목록"),
+                                fieldWithPath("markets[].id").description("마켓 ID"),
+                                fieldWithPath("markets[].name").description("마켓 이름"),
+                                fieldWithPath("markets[].description").description("마켓 한줄 소개"),
+                                fieldWithPath("markets[].thumbnail").description("마켓 썸네일 이미지 URL"),
+                                fieldWithPath("markets[].totalSales").description("총 판매 수량"),
+                                fieldWithPath("markets[].totalReviews").description("총 리뷰 개수")
                         })));
     }
 }


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #27 
- close #42 
- close #43 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
### 1️⃣ 인기순 정렬 가중치 계산
> 인기 점수 = 총 판매량 + (총 리뷰 수 × 2) + (신규 마켓 가중치)
 신규 마켓 가중치 = 임의 상수 지정

위 공식에서 임의 상수로 `100` 적용하여 구현했습니다.

### 2️⃣ 마켓 엔티티 수정
- 이전 회의에서 언급되었던 사항 반영했습니다. (`freeDeliveryLimit` 추가)
- 빌더에서 값이 무조건 0으로 초기화되는 오류를 수정했습니다.
    `this.totalSales = totalSales != null ? totalSales : 0L;`

### 3️⃣ 로직 구현
- 카테고리별 랜덤 top5 조회 로직: 기존 카테고리별 top30 로직에서 5개를 랜덤으로 뽑도록 구현했습니다.
- 똑같은 가중치 계산 쿼리가 각 메소드에 반복적으로 사용되고 있어서 추후 해당 로직을 별도의 함수로 빼서 재사용할 수 있도록 리팩토링할 예정입니다...!

### 4️⃣ restdocs
> 이전에 작성했던 카테고리별 마켓 목록 조회에서도 총 리뷰 수, 총 판매량이 null로 표기되어 있어서 다시 전문 첨부합니다.

인기순 조회 메서드가 최소 5개, 최대 30개씩 조회하는 로직이라 정확한 테스트를 위해 목데이터 생성 함수를 따로 만들어서 각 카테고리별(쿠키, 빵, 구움과자) 마켓을 40개씩 총 120개를 만들어 테스트를 진행했습니다.
![source (2)](https://github.com/user-attachments/assets/f4a05819-76c5-41e6-9980-4d9a75e5ba5c)



## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
하나 겨우 만들 때마다 버그는 3개씩 생기는 마법... 뭘까요...
페이지네이션 처리 과정에서 토탈 페이지 수 카운팅에 오류가 있어서 #43 에서 따로 버그 잡고 다시 pr 올리겠습니다.

