### PR TITLE
[Refact] 인기순 계산 함수 분리 및 페이지네이션 설명

### DIFF
--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -30,6 +30,13 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         this.queryFactory = queryFactory;
     }
 
+    private NumberExpression<Double> calculatePopularityScore(QMarketEntity market) {
+        return market.totalSales
+                .coalesce(0L).castToNum(Double.class)
+                .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
+                .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
+    }
+
     @Override
     public Page<MarketEntity> findMarketsByCategory(Long categoryId, Pageable pageable) {
         QMarketEntity market = QMarketEntity.marketEntity;
@@ -61,10 +68,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
     public Page<MarketEntity> findTop10MarketsByPopularity(Pageable pageable) {
         QMarketEntity market = QMarketEntity.marketEntity;
 
-        NumberExpression<Double> popularityScore = market.totalSales
-                .coalesce(0L).castToNum(Double.class)
-                .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
-                .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
+        NumberExpression<Double> popularityScore = calculatePopularityScore(market);
 
         List<MarketEntity> markets = queryFactory
                 .selectFrom(market)
@@ -85,11 +89,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         QMarketEntity market = QMarketEntity.marketEntity;
         QMarketCategoryEntity marketCategory = QMarketCategoryEntity.marketCategoryEntity;
         QCategoryEntity category = QCategoryEntity.categoryEntity;
-
-        NumberExpression<Double> popularityScore = market.totalSales
-                .coalesce(0L).castToNum(Double.class)
-                .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
-                .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
+        NumberExpression<Double> popularityScore = calculatePopularityScore(market);
 
         JPQLQuery<Long> subQuery = JPAExpressions
                 .select(market.id)
@@ -119,10 +119,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         QMarketCategoryEntity marketCategory = QMarketCategoryEntity.marketCategoryEntity;
         QCategoryEntity category = QCategoryEntity.categoryEntity;
 
-        NumberExpression<Double> popularityScore = market.totalSales
-                .coalesce(0L).castToNum(Double.class)
-                .add(market.totalReviews.coalesce(0L).castToNum(Double.class).multiply(2.0))
-                .add(Expressions.numberTemplate(Double.class, "GREATEST(0, {0})", 100));
+        NumberExpression<Double> popularityScore = calculatePopularityScore(market);
 
         List<MarketEntity> top30Markets = queryFactory
                 .select(market)


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #48 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
### 1️⃣ 작업 내용
각 메서드에 중복으로 작성된 인기순 계산 로직을 `calculatePopularityScore()` 함수로 분리하여 코드 중복을 제거하고 재사용할 수 있도록 변경했습니다.

### 2️⃣ 페이지네이션 쿼리 설명(이전 PR #43)
#### 🔎 기존 쿼리
```java
List<MarketEntity> markets = queryFactory
    .selectFrom(market)
    ...
    .limit(30)
    .fetch();

long total = queryFactory
    .select(market.countDistinct())
    ...
    .fetchOne();

return new PageImpl<>(markets, pageable, total);
```
기존 코드에서는 인기순 정렬 후 `상위 30개의 마켓`만 조회했지만 `PageImpl` 생성 시 total 값을 `조건에 맞는 전체 마켓 수`로 잘못 설정하고 있었습니다.

#### 🔎 수정된 쿼리
1. 기존과 동일하게 인기순으로 상위 30개를 먼저 조회합니다.
2. 조건에 맞는 전체 마켓 수를 조회하되, 페이지 계산에 사용하는 값을 30으로 제한합니다.
```java
// 조건에 맞는 전체 마켓 수
long rawTotal = queryFactory
                .select(market.countDistinct())
                .from(marketCategory)
                .join(marketCategory.market, market)
                .join(marketCategory.category, category)
                .where(
                        category.id.eq(categoryId)
                                .and(market.createAt.isNotNull())
                )
                .fetchOne();
        // 실제 페이지 계산에 사용하는 값 -> 최대 30으로 제한
        long total = Math.min(rawTotal, 30);
```

3. top30Markets 리스트에서 offset 기준으로 자르고 PageImpl에 데이터와 total을 적용합니다.
```java
int offset = (int) pageable.getOffset();
int pageSize = pageable.getPageSize();
int end = Math.min(offset + pageSize, totalInt);

List<MarketEntity> pageContent = top30Markets.subList(offset, end);

return new PageImpl<>(pageContent, pageable, total);
```


## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
일단 지금은 인기순 상위 30개만 조회하는 쿼리라서 limit(30)으로 db에서 인기순 정렬된 마켓 30개만 가져오고, 거기서 pageable로 잘라서 반환하도록 구현했는데 

이후에 인기순으로 전체 마켓을 조회한다면 쿼리 자체를 변경해서 db에서 정렬 + 페이징까지 다 처리하도록 변경할 생각입니다!!
아마 지원님이 리뷰에 달아 주신 게 이 방법인 것 같은데 일단 상위 30개만 사용할 때는 지금 방법이 성능이 더 좋아 보여서 그대로 뒀습니다!

변경하게 된다면 지원님 코멘트 반영해서 아래처럼 수정할 예정입니다...!

```java
List<MarketEntity> markets = queryFactory
    .select(market)
    .from(marketCategory)
    .join(marketCategory.market, market)
    .join(marketCategory.category, category)
    .where(
        category.id.eq(categoryId)
            .and(market.createAt.isNotNull())
    )
    .groupBy(
        market.id,
        market.createAt,
        market.description,
        market.name,
        market.thumbnail,
        market.totalReviews,
        market.totalSales
    )
    .orderBy(popularityScore.desc())
    .offset(pageable.getOffset())
    .limit(pageable.getPageSize())
    .fetch();
```