### PR TITLE
[Refact] 상품 카테고리 분류 로직 리팩토링

### DIFF
--- a/src/docs/CategoryRestDocs.adoc
+++ b/src/docs/CategoryRestDocs.adoc
@@ -22,4 +22,19 @@ include::{snippets}/categories/get-all-category/http-response.adoc[]
 
 include::{snippets}/categories/get-all-category/response-fields.adoc[]
 
+=== 1. 카테고리 대분류 목록 조회
+
+==== HTTP request
+
+include::{snippets}/categories/get-main-category/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/categories/get-main-category/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/categories/get-main-category/response-fields.adoc[]
+
+
 

--- a/src/docs/CategoryRestDocs.adoc
+++ b/src/docs/CategoryRestDocs.adoc
@@ -1,0 +1,25 @@
+= API 문서
+Fondant Backend Team
+2025-01-26
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:sectlinks:
+
+== Category API
+
+=== 1. 마켓, 카테고리별 상품 목록 조회
+
+==== HTTP request
+
+include::{snippets}/categories/get-all-category/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/categories/get-all-category/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/categories/get-all-category/response-fields.adoc[]
+
+

--- a/src/docs/CategoryRestDocs.adoc
+++ b/src/docs/CategoryRestDocs.adoc
@@ -8,7 +8,7 @@ Fondant Backend Team
 
 == Category API
 
-=== 1. 마켓, 카테고리별 상품 목록 조회
+=== 1. 카테고리 목록 전체 조회
 
 ==== HTTP request
 

--- a/src/main/java/com/fondant/market/domain/entity/MarketCategoryEntity.java
+++ b/src/main/java/com/fondant/market/domain/entity/MarketCategoryEntity.java
@@ -1,6 +1,6 @@
 package com.fondant.market.domain.entity;
 
-import com.fondant.product.domain.entity.CategoryEntity;
+import com.fondant.product.category.domain.CategoryEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -5,7 +5,7 @@ import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.market.domain.entity.QMarketCategoryEntity;
 import com.fondant.market.domain.entity.QMarketEntity;
 import com.fondant.market.exception.MarketError;
-import com.fondant.product.domain.entity.QCategoryEntity;
+import com.fondant.product.category.domain.QCategoryEntity;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;

--- a/src/main/java/com/fondant/product/application/ProductService.java
+++ b/src/main/java/com/fondant/product/application/ProductService.java
@@ -5,6 +5,7 @@ import com.fondant.global.exception.ApiException;
 import com.fondant.product.application.dto.ImageInfo;
 import com.fondant.product.application.dto.OptionInfo;
 import com.fondant.product.application.dto.ProductInfo;
+import com.fondant.product.category.application.CategoryService;
 import com.fondant.product.domain.entity.ImageType;
 import com.fondant.product.domain.entity.OptionEntity;
 import com.fondant.product.domain.entity.ProductEntity;
@@ -25,12 +26,14 @@ import java.util.List;
 
 @Service
 public class ProductService {
+    private final CategoryService categoryService;
     private final ProductRepository productRepository;
     private final ProductImageRepository productImageRepository;
     private final OptionRepository optionRepository;
 
     @Autowired
-    public ProductService(ProductRepository productRepository, ProductImageRepository productImageRepository, OptionRepository optionRepository) {
+    public ProductService(CategoryService categoryService, ProductRepository productRepository, ProductImageRepository productImageRepository, OptionRepository optionRepository) {
+        this.categoryService = categoryService;
         this.productRepository = productRepository;
         this.productImageRepository = productImageRepository;
         this.optionRepository = optionRepository;
@@ -49,6 +52,8 @@ public class ProductService {
                 .products(getProductInfos(products.getContent()))
                 .build();
     }
+
+
 
     public List<ProductInfo> getProductInfos(List<ProductEntity> products) {
         return products.stream()

--- a/src/main/java/com/fondant/product/category/application/CategoryService.java
+++ b/src/main/java/com/fondant/product/category/application/CategoryService.java
@@ -1,0 +1,47 @@
+package com.fondant.product.category.application;
+
+import com.fondant.product.category.domain.CategoryEntity;
+import com.fondant.product.category.domain.repository.CategoryRepository;
+import com.fondant.product.category.application.dto.CategoryInfo;
+import com.fondant.product.category.application.dto.MainCategoryInfo;
+import com.fondant.product.category.presentation.dto.response.CategoriesResponse;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    @Transactional
+    public CategoriesResponse<MainCategoryInfo> getAllCategories(){
+        List<CategoryEntity> categories = categoryRepository.findAll();
+
+        return CategoriesResponse.of(categories.stream()
+                .map(this::toMainCategoryInfo)
+                .toList());
+    }
+
+    public MainCategoryInfo toMainCategoryInfo(CategoryEntity category) {
+        return MainCategoryInfo.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .subCategories(
+                        category.getChildren().stream()
+                                .map(this::toCategoryInfo)
+                                .toList())
+                .build();
+    }
+
+    public CategoryInfo toCategoryInfo(CategoryEntity category) {
+        return new CategoryInfo(
+                category.getId(),
+                category.getName()
+        );
+    }
+}

--- a/src/main/java/com/fondant/product/category/application/CategoryService.java
+++ b/src/main/java/com/fondant/product/category/application/CategoryService.java
@@ -9,6 +9,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class CategoryService {
@@ -43,5 +44,10 @@ public class CategoryService {
                 category.getId(),
                 category.getName()
         );
+    }
+
+    private List<Long> getAllChildren(Long parentId) {
+        List<CategoryEntity> children = categoryRepository.getByParentId(parentId);
+        return children.stream().map(CategoryEntity::getId).toList();
     }
 }

--- a/src/main/java/com/fondant/product/category/application/CategoryService.java
+++ b/src/main/java/com/fondant/product/category/application/CategoryService.java
@@ -46,6 +46,15 @@ public class CategoryService {
         );
     }
 
+    @Transactional
+    public CategoriesResponse<CategoryInfo> getAllMainCategories(){
+        List<CategoryEntity> categories = categoryRepository.findAllByChildrenIsNotNull();
+
+        return CategoriesResponse.of(categories.stream()
+                .map(this::toCategoryInfo)
+                .toList());
+    }
+
     private List<Long> getAllChildren(Long parentId) {
         List<CategoryEntity> children = categoryRepository.getByParentId(parentId);
         return children.stream().map(CategoryEntity::getId).toList();

--- a/src/main/java/com/fondant/product/category/application/CategoryService.java
+++ b/src/main/java/com/fondant/product/category/application/CategoryService.java
@@ -21,7 +21,7 @@ public class CategoryService {
 
     @Transactional
     public CategoriesResponse<MainCategoryInfo> getAllCategories(){
-        List<CategoryEntity> categories = categoryRepository.findAll();
+        List<CategoryEntity> categories = categoryRepository.findAllByChildrenIsNotNull();
 
         return CategoriesResponse.of(categories.stream()
                 .map(this::toMainCategoryInfo)

--- a/src/main/java/com/fondant/product/category/application/dto/CategoryInfo.java
+++ b/src/main/java/com/fondant/product/category/application/dto/CategoryInfo.java
@@ -1,0 +1,10 @@
+package com.fondant.product.category.application.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CategoryInfo(
+        Long id,
+        String name
+) {
+}

--- a/src/main/java/com/fondant/product/category/application/dto/MainCategoryInfo.java
+++ b/src/main/java/com/fondant/product/category/application/dto/MainCategoryInfo.java
@@ -1,0 +1,13 @@
+package com.fondant.product.category.application.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MainCategoryInfo(
+        Long id,
+        String name,
+        List<CategoryInfo> subCategories
+) {
+}

--- a/src/main/java/com/fondant/product/category/domain/CategoryEntity.java
+++ b/src/main/java/com/fondant/product/category/domain/CategoryEntity.java
@@ -1,8 +1,11 @@
-package com.fondant.product.domain.entity;
+package com.fondant.product.category.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,10 +19,25 @@ public class CategoryEntity {
 
     @NotNull
     @Column(name="name")
+    @Getter
     private String name;
+
+    @Getter
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private CategoryEntity parent;
+
+    @OneToMany(mappedBy = "parent",cascade = CascadeType.ALL, orphanRemoval = true)
+    @Getter
+    private List<CategoryEntity> children = new ArrayList<>();;
 
     @Builder
     public CategoryEntity(String name) {
         this.name = name;
+    }
+
+    public void addChild(CategoryEntity child) {
+        this.children.add(child);
+        child.parent = this;
     }
 }

--- a/src/main/java/com/fondant/product/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/fondant/product/category/domain/repository/CategoryRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<CategoryEntity,Long> {
+    List<CategoryEntity> findAllByChildrenIsNotNull();
     List<CategoryEntity> getByParentId(Long parentId);
 }

--- a/src/main/java/com/fondant/product/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/fondant/product/category/domain/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.fondant.product.category.domain.repository;
+
+import com.fondant.product.category.domain.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<CategoryEntity,Long> {
+}

--- a/src/main/java/com/fondant/product/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/fondant/product/category/domain/repository/CategoryRepository.java
@@ -3,5 +3,8 @@ package com.fondant.product.category.domain.repository;
 import com.fondant.product.category.domain.CategoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<CategoryEntity,Long> {
+    List<CategoryEntity> getByParentId(Long parentId);
 }

--- a/src/main/java/com/fondant/product/category/presentation/CategoryController.java
+++ b/src/main/java/com/fondant/product/category/presentation/CategoryController.java
@@ -22,4 +22,11 @@ public class CategoryController {
                 categoryService.getAllCategories()
         ));
     }
+
+    @GetMapping("/main")
+    public ResponseEntity<ResponseDto<CategoriesResponse>> getAllMainCategories() {
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                categoryService.getAllMainCategories()
+        ));
+    }
 }

--- a/src/main/java/com/fondant/product/category/presentation/CategoryController.java
+++ b/src/main/java/com/fondant/product/category/presentation/CategoryController.java
@@ -1,0 +1,25 @@
+package com.fondant.product.category.presentation;
+
+import com.fondant.global.dto.ResponseDto;
+import com.fondant.global.dto.SuccessMessage;
+import com.fondant.product.category.application.CategoryService;
+import com.fondant.product.category.presentation.dto.response.CategoriesResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/category")
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<ResponseDto<CategoriesResponse>> getAllCategories() {
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                categoryService.getAllCategories()
+        ));
+    }
+}

--- a/src/main/java/com/fondant/product/category/presentation/dto/response/CategoriesResponse.java
+++ b/src/main/java/com/fondant/product/category/presentation/dto/response/CategoriesResponse.java
@@ -1,0 +1,11 @@
+package com.fondant.product.category.presentation.dto.response;
+
+import java.util.List;
+
+public record CategoriesResponse<D>(
+        List<D> categories
+) {
+    public static <D> CategoriesResponse<D> of(List<D> categories) {
+        return new CategoriesResponse<>(categories);
+    }
+}

--- a/src/main/java/com/fondant/product/domain/entity/ProductCategoryEntity.java
+++ b/src/main/java/com/fondant/product/domain/entity/ProductCategoryEntity.java
@@ -26,6 +26,7 @@ public class ProductCategoryEntity {
     @JoinColumn(name = "category_id")
     private CategoryEntity category;
 
+
     @Builder
     public ProductCategoryEntity(ProductEntity product, CategoryEntity category) {
         this.product = product;

--- a/src/main/java/com/fondant/product/domain/entity/ProductCategoryEntity.java
+++ b/src/main/java/com/fondant/product/domain/entity/ProductCategoryEntity.java
@@ -1,5 +1,6 @@
 package com.fondant.product.domain.entity;
 
+import com.fondant.product.category.domain.CategoryEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
@@ -1,8 +1,9 @@
 package com.fondant.product.domain.repository;
 
+import com.fondant.global.config.PageConfig;
 import com.fondant.market.domain.entity.QMarketEntity;
+import com.fondant.product.category.domain.QCategoryEntity;
 import com.fondant.product.domain.entity.ProductEntity;
-import com.fondant.product.domain.entity.QCategoryEntity;
 import com.fondant.product.domain.entity.QProductCategoryEntity;
 import com.fondant.product.domain.entity.QProductEntity;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,36 +22,63 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long categoryId, Pageable pageable) {
-        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
-        QProductEntity product = QProductEntity.productEntity;
-        QMarketEntity market = QMarketEntity.marketEntity;
+    public Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long mainCategoryId, Pageable pageable) {
+        List<Long> subCategoryIds = findSubCategoryIdsByMainCategory(mainCategoryId);
 
-        List<ProductEntity> content = queryFactory
-                .select(product)
-                .from(productCategory)
-                .join(productCategory.product, product)
-                .join(product.market, market)
+        if (subCategoryIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<ProductEntity> content = findProductsByMarketAndSubCategories(marketId, subCategoryIds, pageable);
+        Long total = countProductsByMarketAndSubCategories(marketId, subCategoryIds);
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0);
+    }
+
+    private List<Long> findSubCategoryIdsByMainCategory(Long mainCategoryId) {
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        return queryFactory
+                .select(category.id)
+                .from(category)
+                .where(category.parent.id.eq(mainCategoryId))
+                .fetch();
+    }
+
+    private List<ProductEntity> findProductsByMarketAndSubCategories(Long marketId, List<Long> subCategoryIds, Pageable pageable) {
+        QProductEntity product = QProductEntity.productEntity;
+        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        return queryFactory
+                .selectDistinct(product)
+                .from(product)
+                .join(productCategory).on(product.eq(productCategory.product))
+                .join(productCategory.category, category)
                 .where(
-                        productCategory.category.id.eq(categoryId),
-                        product.market.id.eq(marketId)
+                        product.market.id.eq(marketId),
+                        category.id.in(subCategoryIds)
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+    }
 
-        long total = queryFactory
-                .select(product.count())
-                .from(productCategory)
-                .join(productCategory.product, product)
-                .join(product.market, market)
+    private Long countProductsByMarketAndSubCategories(Long marketId, List<Long> subCategoryIds) {
+        QProductEntity product = QProductEntity.productEntity;
+        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        return queryFactory
+                .select(product.countDistinct())
+                .from(product)
+                .join(productCategory).on(product.eq(productCategory.product))
+                .join(productCategory.category, category)
                 .where(
-                        productCategory.category.id.eq(categoryId),
-                        product.market.id.eq(marketId)
+                        product.market.id.eq(marketId),
+                        category.id.in(subCategoryIds)
                 )
                 .fetchOne();
-
-        return new PageImpl<>(content, pageable, total);
     }
 }
 

--- a/src/main/java/com/fondant/product/presentation/ProductController.java
+++ b/src/main/java/com/fondant/product/presentation/ProductController.java
@@ -1,5 +1,6 @@
 package com.fondant.product.presentation;
 
+import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.ResponseDto;
 import com.fondant.global.dto.SuccessMessage;
 import com.fondant.product.application.ProductService;
@@ -17,9 +18,11 @@ public class ProductController {
     private static int PAGE_SIZE = 10;
 
     private final ProductService productService;
+    private final PageConfig pageConfig;
 
-    public ProductController(ProductService productService) {
+    public ProductController(ProductService productService, PageConfig pageConfig) {
         this.productService = productService;
+        this.pageConfig = pageConfig;
     }
 
     @GetMapping("/{marketId}/{categoryId}")
@@ -27,10 +30,8 @@ public class ProductController {
             @PathVariable(name="marketId") Long marketId,
             @PathVariable(name="categoryId") Long categoryId,
             @RequestParam(name="page") int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
-                productService.getProductsByMarketAndCategoryId(marketId,categoryId,pageable)));
+                productService.getProductsByMarketAndCategoryId(marketId,categoryId, pageConfig.defaultPageable())));
     }
 
     @GetMapping("/{productId}")

--- a/src/main/java/com/fondant/test/repository/CategoryTestRepository.java
+++ b/src/main/java/com/fondant/test/repository/CategoryTestRepository.java
@@ -1,6 +1,6 @@
 package com.fondant.test.repository;
 
-import com.fondant.product.domain.entity.CategoryEntity;
+import com.fondant.product.category.domain.CategoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryTestRepository extends JpaRepository<CategoryEntity,Long> {

--- a/src/main/java/com/fondant/user/presentation/DeliveryAddressController.java
+++ b/src/main/java/com/fondant/user/presentation/DeliveryAddressController.java
@@ -23,19 +23,19 @@ public class DeliveryAddressController {
         this.userService = userService;
     }
 
-    @GetMapping("")
+    @GetMapping("/")
     public ResponseEntity<ResponseDto<List<DeliveryAddressResponse>>> getDeliveryAddress(@CurrentUser CustomUserDetails user) {
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
                 userService.getDeliveryAddress(user.getUserId())));
     }
 
-    @PostMapping("")
+    @PostMapping("/")
     public ResponseEntity<ResponseDto<Void>> addDeliveryAddress(@CurrentUser CustomUserDetails user, @RequestBody DeliveryAddressAddRequest request) {
         userService.addDeliveryAddress(user.getUserId(), request);
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
     }
 
-    @PatchMapping("")
+    @PatchMapping("/")
     public ResponseEntity<ResponseDto<Void>> updateDeliveryAddress(@CurrentUser CustomUserDetails user, @RequestBody DeliveryAddressUpdateRequest request) {
         userService.updateDeliveryAddress(user.getUserId(), request);
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));

--- a/src/main/java/com/fondant/user/presentation/UserController.java
+++ b/src/main/java/com/fondant/user/presentation/UserController.java
@@ -29,13 +29,13 @@ public class UserController {
         this.reissueService = reissueService;
     }
 
-    @GetMapping("")
+    @GetMapping("/")
     public ResponseEntity<ResponseDto<UserResponse>> getUserInfo(@CurrentUser CustomUserDetails user) {
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
                 userService.getUserInfo(user.getUserId())));
     }
 
-    @PatchMapping("")
+    @PatchMapping("/")
     public ResponseEntity<ResponseDto<Void>> updateUserInfo(@CurrentUser CustomUserDetails user, @RequestBody UserUpdateRequest request) {
         userService.updateUserInfo(user.getUserId(), request);
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));

--- a/src/main/java/com/fondant/wishlist/application/WishListController.java
+++ b/src/main/java/com/fondant/wishlist/application/WishListController.java
@@ -1,8 +1,10 @@
 package com.fondant.wishlist.application;
 
+import com.fondant.global.annotation.CurrentUser;
 import com.fondant.global.dto.ResponseDto;
 import com.fondant.global.dto.SuccessMessage;
 import com.fondant.product.presentation.dto.response.ProductsResponse;
+import com.fondant.user.application.dto.CustomUserDetails;
 import com.fondant.wishlist.application.dto.request.WishListRegistRequest;
 import com.fondant.wishlist.presentation.WishListService;
 
@@ -24,19 +26,20 @@ public class WishListController {
 
     @PostMapping("")
     public ResponseEntity<ResponseDto<Void>> registerWishlist(
+            @CurrentUser CustomUserDetails user,
             @RequestBody WishListRegistRequest request
             ){
-        wishListService.registerWishList(request.userId(), request.productId());
+        wishListService.registerWishList(user.getUserId(), request.productId());
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.CREATE_SUCCESS));
     }
 
     @GetMapping("")
     public ResponseEntity<ResponseDto<ProductsResponse>> getWishLists(
-            @RequestParam Long userId,
+            @CurrentUser CustomUserDetails user,
             @RequestParam(name="page") int page
     ){
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
-                wishListService.getWishList(userId,pageable)));
+                wishListService.getWishList(user.getUserId(),pageable)));
     }
 }

--- a/src/test/java/com/fondant/restdocs/CategoryRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/CategoryRestDocsTest.java
@@ -1,0 +1,143 @@
+package com.fondant.restdocs;
+
+import com.fondant.infra.jwt.application.JWTUtil;
+import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.product.category.domain.CategoryEntity;
+import com.fondant.product.domain.entity.*;
+import com.fondant.product.domain.repository.OptionRepository;
+import com.fondant.product.domain.repository.ProductImageRepository;
+import com.fondant.product.domain.repository.ProductRepository;
+import com.fondant.test.repository.CategoryTestRepository;
+import com.fondant.test.repository.MarketTestRepository;
+import com.fondant.test.repository.ProductCategoryTestRepository;
+import com.fondant.test.repository.UserTestRepository;
+import com.fondant.user.domain.entity.Gender;
+import com.fondant.user.domain.entity.SNSType;
+import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.domain.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriScheme = "http", uriHost = "localhost", uriPort = 8080)
+@Transactional
+public class CategoryRestDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CategoryTestRepository categoryRepository;
+
+    @Autowired
+    private ProductImageRepository productImageRepository;
+
+    @Autowired
+    private UserTestRepository userRepository;
+
+    @MockitoSpyBean
+    private JWTUtil jwtUtil;
+
+    private CategoryEntity category1;
+    private CategoryEntity category2;
+    private UserEntity testUser;
+    private String mockToken;
+
+    private static final String BASE_URL = "/api/category";
+
+    @BeforeEach
+    void setUp() {
+        category1 = categoryRepository.save(CategoryEntity.builder()
+                .name("초콜릿")
+                .build());
+
+        category1.addChild(CategoryEntity.builder()
+                .name("화이트초콜릿")
+                .build());
+
+        category1.addChild(CategoryEntity.builder()
+                .name("다크초콜릿")
+                .build());
+
+        category2 = categoryRepository.save(CategoryEntity.builder()
+                .name("쿠키")
+                .build());
+
+        category2.addChild(CategoryEntity.builder()
+                .name("르벵쿠키")
+                .build());
+
+        category2.addChild(CategoryEntity.builder()
+                .name("비건쿠키")
+                .build());
+
+        testUser = userRepository.save(
+                UserEntity.builder()
+                        .snsType(SNSType.NAVER)
+                        .name("test-user")
+                        .phoneNumber("010-0000-0000")
+                        .email("test-user@example.com")
+                        .birth(Date.valueOf(LocalDate.of(2001, 1, 1)))
+                        .nickname("test-user-nickname")
+                        .profileUrl("https://example.com")
+                        .createAt(Date.valueOf(LocalDate.of(2025, 1, 1)).toLocalDate())
+                        .gender(Gender.FEMALE)
+                        .role(UserRole.USER)
+                        .build()
+        );
+
+        mockToken = jwtUtil.generateToken("access", testUser.getId(), "USER", 60 * 10 * 1000L);
+
+    }
+
+    public static FieldDescriptor[] commonResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("code").description("요청 성공 여부 (true/false)"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("response").description("응답 데이터")
+        };
+    }
+
+    @Test
+    void getAllCategories() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/all")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken))
+                .andExpect(status().isOk())
+                .andDo(document("categories/get-all-category",
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[] {
+                                fieldWithPath("categories[]").description("대분류 카테고리 목록"),
+                                fieldWithPath("categories[].id").description("대분류 카테고리 아이디"),
+                                fieldWithPath("categories[].name").description("대분류 카테고리 이름"),
+                                fieldWithPath("categories[].subCategories[]").description("소분류 카테고리 목록"),
+                                fieldWithPath("categories[].subCategories[].id").description("소분류 카테고리 아이디"),
+                                fieldWithPath("categories[].subCategories[].name").description("소분류 카테고리 이름"),
+                        })));
+    }
+}

--- a/src/test/java/com/fondant/restdocs/CategoryRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/CategoryRestDocsTest.java
@@ -140,4 +140,20 @@ public class CategoryRestDocsTest {
                                 fieldWithPath("categories[].subCategories[].name").description("소분류 카테고리 이름"),
                         })));
     }
+
+    @Test
+    void getAllMainCategories() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/main")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken))
+                .andExpect(status().isOk())
+                .andDo(document("categories/get-main-category",
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[] {
+                                fieldWithPath("categories[]").description("대분류 카테고리 목록"),
+                                fieldWithPath("categories[].id").description("대분류 카테고리 아이디"),
+                                fieldWithPath("categories[].name").description("대분류 카테고리 이름")
+                        })));
+    }
 }

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -1,22 +1,32 @@
 package com.fondant.restdocs;
 
+import com.fondant.infra.jwt.application.JWTUtil;
 import com.fondant.market.domain.entity.MarketCategoryEntity;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.product.domain.entity.CategoryEntity;
 import com.fondant.test.repository.CategoryTestRepository;
 import com.fondant.test.repository.MarketCategoryTestRepository;
 import com.fondant.test.repository.MarketTestRepository;
+import com.fondant.test.repository.UserTestRepository;
+import com.fondant.user.domain.entity.Gender;
+import com.fondant.user.domain.entity.SNSType;
+import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.domain.entity.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.sql.Date;
+import java.time.LocalDate;
 import java.util.Arrays;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -46,9 +56,17 @@ public class MarketRestDocsTest {
     @Autowired
     private MarketCategoryTestRepository marketCategoryRepository;
 
+    @Autowired
+    private UserTestRepository userRepository;
+
+    @MockitoSpyBean
+    private JWTUtil jwtUtil;
+
     private CategoryEntity categoryCookie;
     private CategoryEntity categoryBread;
     private CategoryEntity categoryBakedGoods;
+    private UserEntity testUser;
+    private String mockToken;
 
     private static final String BASE_URL = "/api/markets";
 
@@ -93,6 +111,23 @@ public class MarketRestDocsTest {
                 marketCount++;
             }
         }
+
+        testUser = userRepository.save(
+                UserEntity.builder()
+                        .snsType(SNSType.NAVER)
+                        .name("test-user")
+                        .phoneNumber("010-0000-0000")
+                        .email("test-user@example.com")
+                        .birth(Date.valueOf(LocalDate.of(2001, 1, 1)))
+                        .nickname("test-user-nickname")
+                        .profileUrl("https://example.com")
+                        .createAt(Date.valueOf(LocalDate.of(2025, 1, 1)).toLocalDate())
+                        .gender(Gender.FEMALE)
+                        .role(UserRole.USER)
+                        .build()
+        );
+
+        mockToken = jwtUtil.generateToken("access", testUser.getId(), "USER", 60 * 10 * 1000L);
     }
 
     public static FieldDescriptor[] commonResponseFields() {
@@ -106,6 +141,7 @@ public class MarketRestDocsTest {
     @Test
     void getMarketsByCategory() throws Exception {
         mockMvc.perform(get(BASE_URL + "/categories/{categoryId}", categoryBread.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -137,6 +173,7 @@ public class MarketRestDocsTest {
     void getMarketById() throws Exception {
         MarketEntity market = marketRepository.findAll().get(0);
         mockMvc.perform(get(BASE_URL + "/{marketId}", market.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(document("markets/get-market-by-id",
@@ -159,6 +196,7 @@ public class MarketRestDocsTest {
     @Test
     void getTop10MarketsByPopularity() throws Exception {
         mockMvc.perform(get(BASE_URL + "/top10")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -187,6 +225,7 @@ public class MarketRestDocsTest {
     @Test
     void getTop30MarketsByCategory() throws Exception {
         mockMvc.perform(get(BASE_URL + "/{categoryId}/top30", categoryCookie.getId())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                 .param("page", "0")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -218,6 +257,7 @@ public class MarketRestDocsTest {
     @Test
     void getRandomTop5MarketsByCategory() throws Exception {
         mockMvc.perform(get(BASE_URL + "/{categoryId}/top5", categoryCookie.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -3,7 +3,7 @@ package com.fondant.restdocs;
 import com.fondant.infra.jwt.application.JWTUtil;
 import com.fondant.market.domain.entity.MarketCategoryEntity;
 import com.fondant.market.domain.entity.MarketEntity;
-import com.fondant.product.domain.entity.CategoryEntity;
+import com.fondant.product.category.domain.CategoryEntity;
 import com.fondant.test.repository.CategoryTestRepository;
 import com.fondant.test.repository.MarketCategoryTestRepository;
 import com.fondant.test.repository.MarketTestRepository;

--- a/src/test/java/com/fondant/restdocs/OAuth2RestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/OAuth2RestDocsTest.java
@@ -74,7 +74,7 @@ public class OAuth2RestDocsTest {
         mockMvc.perform(post(BASE_URL + "/reissue")
                         .cookie(cookie))
                 .andExpect(status().isOk())
-                .andDo(document("/user/reissue-access-and-refresh-token",
+                .andDo(document("user/reissue-access-and-refresh-token",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestCookies(

--- a/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
@@ -3,6 +3,7 @@ package com.fondant.restdocs;
 
 import com.fondant.infra.jwt.application.JWTUtil;
 import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.product.category.domain.CategoryEntity;
 import com.fondant.product.domain.entity.*;
 import com.fondant.product.domain.repository.OptionRepository;
 import com.fondant.product.domain.repository.ProductImageRepository;

--- a/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
@@ -103,9 +103,29 @@ public class ProductRestDocsTest {
                 .name("초콜릿")
                 .build());
 
+        category1.addChild(CategoryEntity.builder()
+                .name("화이트초콜릿")
+                .build());
+
+        category1.addChild(CategoryEntity.builder()
+                .name("다크초콜릿")
+                .build());
+
+        categoryRepository.save(category1);
+
         category2 = categoryRepository.save(CategoryEntity.builder()
                 .name("쿠키")
                 .build());
+
+        category2.addChild(CategoryEntity.builder()
+                .name("르벵쿠키")
+                .build());
+
+        category2.addChild(CategoryEntity.builder()
+                .name("비건쿠키")
+                .build());
+
+        categoryRepository.save(category2);
 
         product1 = productRepository.save(ProductEntity.builder()
                 .name("두바이 초콜릿")
@@ -129,7 +149,7 @@ public class ProductRestDocsTest {
 
         categoryProduct1 = productCategoryRepository.save(ProductCategoryEntity.builder()
                 .product(product1)
-                .category(category1)
+                .category(category1.getChildren().get(1))
                 .build());
 
         productImage1 = productImageRepository.save(ProductImageEntity.builder()

--- a/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
@@ -1,6 +1,7 @@
 package com.fondant.restdocs;
 
 
+import com.fondant.infra.jwt.application.JWTUtil;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.product.domain.entity.*;
 import com.fondant.product.domain.repository.OptionRepository;
@@ -9,17 +10,25 @@ import com.fondant.product.domain.repository.ProductRepository;
 import com.fondant.test.repository.CategoryTestRepository;
 import com.fondant.test.repository.MarketTestRepository;
 import com.fondant.test.repository.ProductCategoryTestRepository;
+import com.fondant.test.repository.UserTestRepository;
+import com.fondant.user.domain.entity.Gender;
+import com.fondant.user.domain.entity.SNSType;
+import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.domain.entity.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Date;
 import java.time.LocalDate;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -57,6 +66,12 @@ public class ProductRestDocsTest {
     @Autowired
     private OptionRepository optionRepository;
 
+    @Autowired
+    private UserTestRepository userRepository;
+
+    @MockitoSpyBean
+    private JWTUtil jwtUtil;
+
     private MarketEntity market;
     private CategoryEntity category1;
     private CategoryEntity category2;
@@ -68,6 +83,8 @@ public class ProductRestDocsTest {
     private ProductImageEntity productImage2;
     private ProductImageEntity productDetail1;
     private OptionEntity option1;
+    private UserEntity testUser;
+    private String mockToken;
 
     private static final String BASE_URL = "/api/product";
 
@@ -141,6 +158,24 @@ public class ProductRestDocsTest {
                  .productId(product1.getId())
                  .price(20000)
                  .build());
+
+        testUser = userRepository.save(
+                UserEntity.builder()
+                        .snsType(SNSType.NAVER)
+                        .name("test-user")
+                        .phoneNumber("010-0000-0000")
+                        .email("test-user@example.com")
+                        .birth(Date.valueOf(LocalDate.of(2001, 1, 1)))
+                        .nickname("test-user-nickname")
+                        .profileUrl("https://example.com")
+                        .createAt(Date.valueOf(LocalDate.of(2025, 1, 1)).toLocalDate())
+                        .gender(Gender.FEMALE)
+                        .role(UserRole.USER)
+                        .build()
+        );
+
+        mockToken = jwtUtil.generateToken("access", testUser.getId(), "USER", 60 * 10 * 1000L);
+
     }
 
     public static FieldDescriptor[] commonResponseFields() {
@@ -154,6 +189,7 @@ public class ProductRestDocsTest {
     @Test
     void getProductsByMarketAndCategory() throws Exception {
         mockMvc.perform(get(BASE_URL + "/{marketId}/{categoryId}", market.getId(), category1.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -186,7 +222,8 @@ public class ProductRestDocsTest {
     @Test
     void getProductDetails() throws Exception {
         mockMvc.perform(get(BASE_URL + "/{productId}", product1.getId())
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken))
                 .andExpect(status().isOk())
                 .andDo(document("products/get-product-details",
                         preprocessRequest(prettyPrint()),

--- a/src/test/java/com/fondant/restdocs/UserRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/UserRestDocsTest.java
@@ -7,10 +7,7 @@ import com.fondant.test.repository.UserTestRepository;
 import com.fondant.global.annotation.WithMockCustomUser;
 import com.fondant.user.application.UserService;
 import com.fondant.user.application.dto.CustomUserDetails;
-import com.fondant.user.domain.entity.DeliveryAddressEntity;
-import com.fondant.user.domain.entity.Gender;
-import com.fondant.user.domain.entity.UserEntity;
-import com.fondant.user.domain.entity.UserRole;
+import com.fondant.user.domain.entity.*;
 import com.fondant.user.presentation.dto.request.DeliveryAddressAddRequest;
 import com.fondant.user.presentation.dto.request.DeliveryAddressUpdateRequest;
 import com.fondant.user.presentation.dto.request.UserUpdateRequest;
@@ -30,6 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +41,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.sql.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -69,6 +68,7 @@ public class UserRestDocsTest {
     @Autowired
     private UserTestRepository userRepository;
 
+    @MockitoSpyBean
     @Autowired
     private JWTUtil jwtUtil;
 
@@ -87,6 +87,8 @@ public class UserRestDocsTest {
 
     private DeliveryAddressAddRequest address1;
     private DeliveryAddressAddRequest address2;
+    private String mockToken;
+    private UserEntity testUser;
 
     @BeforeEach
     public void setUp() {
@@ -108,13 +110,30 @@ public class UserRestDocsTest {
                 .receiverPhoneNumber("010-9876-5432")
                 .isPrimary(false)
                 .build();
+
+        testUser = userRepository.save(
+                UserEntity.builder()
+                        .snsType(SNSType.NAVER)
+                        .name("test-user")
+                        .phoneNumber("010-0000-0000")
+                        .email("test-user@example.com")
+                        .birth(Date.valueOf(LocalDate.of(2001, 1, 1)))
+                        .nickname("test-user-nickname")
+                        .profileUrl("https://example.com")
+                        .createAt(Date.valueOf(LocalDate.of(2025, 1, 1)).toLocalDate())
+                        .gender(Gender.FEMALE)
+                        .role(UserRole.USER)
+                        .build()
+        );
+
+        mockToken = jwtUtil.generateToken("access", testUser.getId(), "USER", 60 * 10 * 1000L);
     }
 
     @Test
     @WithMockCustomUser
     void getUserInfo() throws Exception {
-
-        mockMvc.perform(get(BASE_URL + "/"))
+        mockMvc.perform(get(BASE_URL + "/")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken))
                 .andExpect(status().isOk())
                 .andDo(document("user/get-user-info",
                 preprocessRequest(prettyPrint()),
@@ -158,6 +177,7 @@ public class UserRestDocsTest {
                 .build();
 
         mockMvc.perform(patch(BASE_URL + "/")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())

--- a/src/test/java/com/fondant/restdocs/WishListRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/WishListRestDocsTest.java
@@ -3,6 +3,7 @@ package com.fondant.restdocs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fondant.infra.jwt.application.JWTUtil;
 import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.product.category.domain.CategoryEntity;
 import com.fondant.product.domain.entity.*;
 import com.fondant.product.domain.repository.OptionRepository;
 import com.fondant.product.domain.repository.ProductImageRepository;
@@ -36,11 +37,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -49,7 +47,6 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/com/fondant/restdocs/WishListRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/WishListRestDocsTest.java
@@ -1,6 +1,7 @@
 package com.fondant.restdocs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fondant.infra.jwt.application.JWTUtil;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.product.domain.entity.*;
 import com.fondant.product.domain.repository.OptionRepository;
@@ -13,25 +14,33 @@ import com.fondant.test.repository.UserTestRepository;
 import com.fondant.user.domain.entity.Gender;
 import com.fondant.user.domain.entity.SNSType;
 import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.domain.entity.UserRole;
 import com.fondant.wishlist.application.dto.request.WishListRegistRequest;
 import com.fondant.wishlist.domain.entity.WishListEntity;
 import com.fondant.wishlist.domain.repository.WishListRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -40,12 +49,15 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs(uriScheme = "http", uriHost = "localhost", uriPort = 8080)
 @Transactional
+@ExtendWith(MockitoExtension.class)
 public class WishListRestDocsTest {
     @Autowired
     private MockMvc mockMvc;
@@ -77,6 +89,10 @@ public class WishListRestDocsTest {
     @Autowired
     private UserTestRepository userRepository;
 
+    @MockitoSpyBean
+    private JWTUtil jwtUtil;
+
+
     private MarketEntity market;
     private CategoryEntity category1;
     private CategoryEntity category2;
@@ -89,11 +105,14 @@ public class WishListRestDocsTest {
     private OptionEntity option1;
     private UserEntity testUser;
     private WishListEntity wishList1;
+    private String mockToken;
 
     private static final String BASE_URL = "/api/wishlist";
 
     @BeforeEach
     void setUp() {
+        mockToken = "jwtToken";
+
         market = marketRepository.save(MarketEntity.builder()
                 .name("퐁당 마켓")
                 .description("신메뉴 업데이트 매달 1일 ! 전국 택배가능 초콜릿 쿠키 전문 퐁당 마켓")
@@ -165,8 +184,11 @@ public class WishListRestDocsTest {
                         .profileUrl("https://example.com")
                         .createAt(Date.valueOf(LocalDate.of(2025, 1, 1)).toLocalDate())
                         .gender(Gender.FEMALE)
+                        .role(UserRole.USER)
                         .build()
         );
+
+        mockToken = jwtUtil.generateToken("access", testUser.getId(), "USER", 60 * 10 * 1000L);
 
         wishList1 = wishListRepository.save(
                 WishListEntity.builder()
@@ -195,6 +217,7 @@ public class WishListRestDocsTest {
 
         //Then
         mockMvc.perform(post(BASE_URL)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -211,9 +234,11 @@ public class WishListRestDocsTest {
     }
 
     @Test
+    @WithMockUser(username = "testUser", roles = {"USER"})
     void getWishList() throws Exception {
         mockMvc.perform(get(BASE_URL)
-                        .param("userId", testUser.getId().toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
+                        .with(user("testUser").roles("USER"))
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -221,12 +246,11 @@ public class WishListRestDocsTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         queryParameters(
-                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
-                                parameterWithName("userId").description("*토큰으로 수정예정")
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)")
                         ),
                         responseFields(
                                 commonResponseFields()
-                        ).andWithPrefix("response.", new FieldDescriptor[] {
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
                                 fieldWithPath("pageInfo").description("페이지 정보"),
                                 fieldWithPath("pageInfo.currentPage").description("현재 페이지"),
                                 fieldWithPath("pageInfo.totalPage").description("전체 페이지"),


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #46 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
1. 카테고리 엔티티 리팩토링
  카테고리 구조가 대분류 - 소분류로 변경됨에 따라 구조가 바뀌었습니다.
  - 모든 상품은 **소분류**를 갖습니다.
  - 대분류로 상품 목록을 조회할 시에는 대분류에 포함되는 소분류의 상품들이 모두 조회됩니다. 
  
    <img width="90%" alt="image" src="https://github.com/user-attachments/assets/2c2d218c-ea2d-4646-83c4-7d15760cf879" />

2. 마켓/카테고리별 상품조회 쿼리 변경
   상품은 소분류 카테고리를 갖고 있으므로 대분류 카테고리로 조회시 해당 소분류 카테고리의 모든 상품을 조회하는 로직이 추가되었습니다.

## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
생각보다 수정사항이 많아서 필터링 로직은 다음 PR에 올리도록 하겠습니다 !
