### PR TITLE
[Feat] 상품 필터링 기능 추가

### DIFF
--- a/src/docs/ProductRestDocs.adoc
+++ b/src/docs/ProductRestDocs.adoc
@@ -48,3 +48,41 @@ include::{snippets}/products/get-product-details/http-response.adoc[]
 
 include::{snippets}/products/get-product-details/response-fields.adoc[]
 
+=== 3. 상품 필터링 개수 조회
+
+==== HTTP request
+
+include::{snippets}/products/get-filtered-product-count/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/products/get-filtered-product-count/query-parameters.adoc[]
+
+
+==== HTTP response
+
+include::{snippets}/products/get-filtered-product-count/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/products/get-filtered-product-count/response-fields.adoc[]
+
+=== 4. 상품 필터링 후 상품 목록 조회
+
+==== HTTP request
+
+include::{snippets}/products/get-filtered-products/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/products/get-filtered-products/query-parameters.adoc[]
+
+
+==== HTTP response
+
+include::{snippets}/products/get-filtered-products/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/products/get-filtered-products/response-fields.adoc[]
+

--- a/src/main/java/com/fondant/global/config/PageConfig.java
+++ b/src/main/java/com/fondant/global/config/PageConfig.java
@@ -29,4 +29,8 @@ public class PageConfig implements WebMvcConfigurer {
         resolver.setMaxPageSize(MAX_SIZE);
         resolvers.add(resolver);
     }
+
+    public Pageable customPageable(int page) {
+        return PageRequest.of(page, DEFAULT_SIZE);
+    }
 }

--- a/src/main/java/com/fondant/product/application/ProductService.java
+++ b/src/main/java/com/fondant/product/application/ProductService.java
@@ -3,10 +3,8 @@ package com.fondant.product.application;
 import com.fondant.global.dto.PageInfo;
 import com.fondant.global.exception.ApiException;
 import com.fondant.market.application.MarketService;
-import com.fondant.market.application.dto.MarketInfo;
 import com.fondant.market.application.dto.MarketInfoForProductDetail;
 import com.fondant.market.domain.entity.MarketEntity;
-import com.fondant.market.domain.repository.MarketRepository;
 import com.fondant.product.application.dto.FilterInfo;
 import com.fondant.product.application.dto.ImageInfo;
 import com.fondant.product.application.dto.OptionInfo;
@@ -15,7 +13,6 @@ import com.fondant.product.category.application.CategoryService;
 import com.fondant.product.domain.entity.ImageType;
 import com.fondant.product.domain.entity.OptionEntity;
 import com.fondant.product.domain.entity.ProductEntity;
-import com.fondant.product.domain.entity.ProductImageEntity;
 import com.fondant.product.domain.repository.OptionRepository;
 import com.fondant.product.domain.repository.ProductImageRepository;
 import com.fondant.product.domain.repository.ProductRepository;
@@ -135,5 +132,19 @@ public class ProductService {
     public FilteredProductCountResponse getFilteredProductCounts(FilterInfo filterInfo) {
         Long count = productRepository.countProductsByFilter(filterInfo);
         return new FilteredProductCountResponse(count);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductsResponse getFilteredProducts(FilterInfo filterInfo,Pageable pageable) {
+        Page<ProductEntity> products = productRepository.findFilteredProducts(filterInfo,pageable);
+
+        if(products.isEmpty()){
+            throw new ApiException(ProductError.NO_PRODUCTS_FOUND);
+        }
+
+        return ProductsResponse.builder()
+                .pageInfo(PageInfo.of(products.getNumber(), products.getTotalPages()))
+                .products(getProductInfos(products.getContent()))
+                .build();
     }
 }

--- a/src/main/java/com/fondant/product/application/ProductService.java
+++ b/src/main/java/com/fondant/product/application/ProductService.java
@@ -5,10 +5,7 @@ import com.fondant.global.exception.ApiException;
 import com.fondant.market.application.MarketService;
 import com.fondant.market.application.dto.MarketInfoForProductDetail;
 import com.fondant.market.domain.entity.MarketEntity;
-import com.fondant.product.application.dto.FilterInfo;
-import com.fondant.product.application.dto.ImageInfo;
-import com.fondant.product.application.dto.OptionInfo;
-import com.fondant.product.application.dto.ProductInfo;
+import com.fondant.product.application.dto.*;
 import com.fondant.product.category.application.CategoryService;
 import com.fondant.product.domain.entity.ImageType;
 import com.fondant.product.domain.entity.OptionEntity;
@@ -27,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ProductService {
@@ -135,8 +133,8 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public ProductsResponse getFilteredProducts(FilterInfo filterInfo,Pageable pageable) {
-        Page<ProductEntity> products = productRepository.findFilteredProducts(filterInfo,pageable);
+    public ProductsResponse getFilteredProducts(FilterInfo filterInfo, Pageable pageable, Optional<SortType> sortType) {
+        Page<ProductEntity> products = productRepository.findFilteredProducts(filterInfo,pageable,sortType);
 
         if(products.isEmpty()){
             throw new ApiException(ProductError.NO_PRODUCTS_FOUND);

--- a/src/main/java/com/fondant/product/application/ProductService.java
+++ b/src/main/java/com/fondant/product/application/ProductService.java
@@ -7,6 +7,7 @@ import com.fondant.market.application.dto.MarketInfo;
 import com.fondant.market.application.dto.MarketInfoForProductDetail;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.market.domain.repository.MarketRepository;
+import com.fondant.product.application.dto.FilterInfo;
 import com.fondant.product.application.dto.ImageInfo;
 import com.fondant.product.application.dto.OptionInfo;
 import com.fondant.product.application.dto.ProductInfo;
@@ -19,6 +20,7 @@ import com.fondant.product.domain.repository.OptionRepository;
 import com.fondant.product.domain.repository.ProductImageRepository;
 import com.fondant.product.domain.repository.ProductRepository;
 import com.fondant.product.exception.ProductError;
+import com.fondant.product.presentation.dto.response.FilteredProductCountResponse;
 import com.fondant.product.presentation.dto.response.ProductDetailResponse;
 import com.fondant.product.presentation.dto.response.ProductsResponse;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,5 +129,11 @@ public class ProductService {
     public ProductEntity getProductById(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new ApiException(ProductError.PRODUCT_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public FilteredProductCountResponse getFilteredProductCounts(FilterInfo filterInfo) {
+        Long count = productRepository.countProductsByFilter(filterInfo);
+        return new FilteredProductCountResponse(count);
     }
 }

--- a/src/main/java/com/fondant/product/application/dto/FilterInfo.java
+++ b/src/main/java/com/fondant/product/application/dto/FilterInfo.java
@@ -1,0 +1,14 @@
+package com.fondant.product.application.dto;
+
+import java.util.List;
+import java.util.Optional;
+
+public record FilterInfo(
+        Optional<Double> startPrice,
+        Optional<Double> endPrice,
+        List<Long> categoryIds,
+        List<String> packingTypes,
+        List<String> benefitTypes
+
+) {
+}

--- a/src/main/java/com/fondant/product/application/dto/SortType.java
+++ b/src/main/java/com/fondant/product/application/dto/SortType.java
@@ -1,0 +1,16 @@
+package com.fondant.product.application.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortType {
+    DISCOUNT("할인순"),
+    REVIEW("리뷰 많은 순"),
+    SALES("판매량 순"),
+    PRICE_ASC("낮은 가격순"),
+    PRICE_DESC("높은 가격순");
+
+    private final String description;
+}

--- a/src/main/java/com/fondant/product/domain/entity/ProductEntity.java
+++ b/src/main/java/com/fondant/product/domain/entity/ProductEntity.java
@@ -62,4 +62,8 @@ public class ProductEntity {
         this.maxCount = maxCount;
         this.discountRate = 0.0;
     }
+
+    public void updateDiscountRate(double discountRate) {
+        this.discountRate = discountRate;
+    }
 }

--- a/src/main/java/com/fondant/product/domain/repository/ProductCategoryRepository.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.fondant.product.domain.repository;
+
+import com.fondant.product.domain.entity.ProductCategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductCategoryRepository extends JpaRepository<ProductCategoryEntity,Long> {
+}

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryCustom.java
@@ -8,4 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface ProductRepositoryCustom {
     Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long categoryId, Pageable pageable);
     Long countProductsByFilter(FilterInfo filterInfo);
+    Page<ProductEntity> findFilteredProducts(FilterInfo filterInfo, Pageable pageable);
 }

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryCustom.java
@@ -1,12 +1,15 @@
 package com.fondant.product.domain.repository;
 
 import com.fondant.product.application.dto.FilterInfo;
+import com.fondant.product.application.dto.SortType;
 import com.fondant.product.domain.entity.ProductEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface ProductRepositoryCustom {
     Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long categoryId, Pageable pageable);
     Long countProductsByFilter(FilterInfo filterInfo);
-    Page<ProductEntity> findFilteredProducts(FilterInfo filterInfo, Pageable pageable);
+    Page<ProductEntity> findFilteredProducts(FilterInfo filterInfo, Pageable pageable, Optional<SortType> sortType);
 }

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryCustom.java
@@ -1,9 +1,11 @@
 package com.fondant.product.domain.repository;
 
+import com.fondant.product.application.dto.FilterInfo;
 import com.fondant.product.domain.entity.ProductEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProductRepositoryCustom {
     Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long categoryId, Pageable pageable);
+    Long countProductsByFilter(FilterInfo filterInfo);
 }

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.fondant.product.domain.repository;
 
 import com.fondant.product.application.dto.FilterInfo;
+import com.fondant.product.application.dto.SortType;
 import com.fondant.product.category.domain.QCategoryEntity;
 import com.fondant.product.domain.entity.ProductEntity;
 import com.fondant.product.domain.entity.QProductCategoryEntity;
@@ -14,6 +15,9 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import static com.fondant.product.application.dto.SortType.*;
 
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
@@ -157,21 +161,21 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public Page<ProductEntity> findFilteredProducts(FilterInfo filterInfo, Pageable pageable) {
-        List<ProductEntity> content = fetchFilteredProducts(filterInfo, pageable);
+    public Page<ProductEntity> findFilteredProducts(FilterInfo filterInfo, Pageable pageable,Optional<SortType> sortType) {
+        List<ProductEntity> content = fetchFilteredProducts(filterInfo, pageable, sortType);
         Long total = fetchFilteredProductsCount(filterInfo);
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
-    private List<ProductEntity> fetchFilteredProducts(FilterInfo filterInfo, Pageable pageable) {
+    private List<ProductEntity> fetchFilteredProducts(FilterInfo filterInfo, Pageable pageable, Optional<SortType> sortType) {
         QProductEntity product = QProductEntity.productEntity;
         QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
         QCategoryEntity category = QCategoryEntity.categoryEntity;
 
         BooleanBuilder builder = buildProductConditions(filterInfo, product);
 
-        return queryFactory
+        JPAQuery<ProductEntity> query = queryFactory
                 .select(product)
                 .from(product)
                 .join(productCategory).on(product.id.eq(productCategory.product.id))
@@ -179,8 +183,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .where(builder)
                 .where(buildCategoryCondition(filterInfo, category))
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .limit(pageable.getPageSize());
+
+        applySort(query, sortType, product);
+
+        return query.fetch();
     }
 
     private Long fetchFilteredProductsCount(FilterInfo filterInfo) {
@@ -199,5 +206,22 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .where(buildCategoryCondition(filterInfo, category))
                 .fetchOne();
     }
+
+    //상품별 판매량 및 리뷰수 구현 필요
+    private void applySort(JPAQuery<ProductEntity> query, Optional<SortType> sortType, QProductEntity product) {
+        if (sortType.isEmpty()) {
+            return;
+        }
+
+        switch (sortType.get()) {
+            case DISCOUNT -> query.orderBy(product.discountRate.desc());
+            //case REVIEW -> query.orderBy(product.market.totalReviews.desc());
+            //case SALES -> query.orderBy(product.market.totalSales.desc());
+            case PRICE_ASC -> query.orderBy(product.price.asc());
+            case PRICE_DESC -> query.orderBy(product.price.desc());
+        }
+    }
+
+
 }
 

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
@@ -1,16 +1,18 @@
 package com.fondant.product.domain.repository;
 
-import com.fondant.global.config.PageConfig;
-import com.fondant.market.domain.entity.QMarketEntity;
+import com.fondant.product.application.dto.FilterInfo;
 import com.fondant.product.category.domain.QCategoryEntity;
 import com.fondant.product.domain.entity.ProductEntity;
 import com.fondant.product.domain.entity.QProductCategoryEntity;
 import com.fondant.product.domain.entity.QProductEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
@@ -80,5 +82,79 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 )
                 .fetchOne();
     }
+
+    @Override
+    public Long countProductsByFilter(FilterInfo filterInfo) {
+        QProductEntity product = QProductEntity.productEntity;
+        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        BooleanBuilder builder = buildProductConditions(filterInfo, product);
+
+        JPAQuery<Long> query = queryFactory
+                .select(product.id.countDistinct())
+                .from(product)
+                .join(productCategory).on(product.id.eq(productCategory.product.id))
+                .join(category).on(productCategory.category.id.eq(category.id))
+                .where(builder)
+                .where(buildCategoryCondition(filterInfo, category));
+
+        return query.fetchOne();
+    }
+
+    private BooleanBuilder buildProductConditions(FilterInfo filterInfo, QProductEntity product) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        filterInfo.startPrice().ifPresent(start -> builder.and(product.price.goe(start)));
+        filterInfo.endPrice().ifPresent(end -> builder.and(product.price.loe(end)));
+
+        // 사용 예정 : packingType 및 coupon 도메인 추가 필요
+        /*
+        if (filterInfo.packingTypes() != null && !filterInfo.packingTypes().isEmpty()) {
+            builder.and(product.packagingType.in(filterInfo.packingTypes()));
+        }
+
+        if (filterInfo.benefitTypes() != null && !filterInfo.benefitTypes().isEmpty()) {
+            builder.and(product.benefit.in(filterInfo.benefitTypes()));
+        }
+        */
+
+        return builder;
+    }
+
+    private BooleanBuilder buildCategoryCondition(FilterInfo filterInfo, QCategoryEntity category) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (filterInfo.categoryIds() != null && !filterInfo.categoryIds().isEmpty()) {
+            List<Long> resolvedIds = resolveCategoryIds(filterInfo.categoryIds());
+
+            if (!resolvedIds.isEmpty()) {
+                builder.and(category.id.in(resolvedIds));
+            }
+        }
+
+        return builder;
+    }
+
+    private List<Long> resolveCategoryIds(List<Long> categoryIds) {
+        if (categoryIds == null || categoryIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> allSubCategoryIds = new ArrayList<>();
+
+        for (Long id : categoryIds) {
+            List<Long> subIds = findSubCategoryIdsByMainCategory(id);
+
+            if (subIds.isEmpty()) {
+                allSubCategoryIds.add(id);
+            } else {
+                allSubCategoryIds.addAll(subIds);
+            }
+        }
+
+        return allSubCategoryIds;
+    }
+
 }
 

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
@@ -156,5 +156,48 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         return allSubCategoryIds;
     }
 
+    @Override
+    public Page<ProductEntity> findFilteredProducts(FilterInfo filterInfo, Pageable pageable) {
+        List<ProductEntity> content = fetchFilteredProducts(filterInfo, pageable);
+        Long total = fetchFilteredProductsCount(filterInfo);
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private List<ProductEntity> fetchFilteredProducts(FilterInfo filterInfo, Pageable pageable) {
+        QProductEntity product = QProductEntity.productEntity;
+        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        BooleanBuilder builder = buildProductConditions(filterInfo, product);
+
+        return queryFactory
+                .select(product)
+                .from(product)
+                .join(productCategory).on(product.id.eq(productCategory.product.id))
+                .join(category).on(productCategory.category.id.eq(category.id))
+                .where(builder)
+                .where(buildCategoryCondition(filterInfo, category))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private Long fetchFilteredProductsCount(FilterInfo filterInfo) {
+        QProductEntity product = QProductEntity.productEntity;
+        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        BooleanBuilder builder = buildProductConditions(filterInfo, product);
+
+        return queryFactory
+                .select(product.id.countDistinct())
+                .from(product)
+                .join(productCategory).on(product.id.eq(productCategory.product.id))
+                .join(category).on(productCategory.category.id.eq(category.id))
+                .where(builder)
+                .where(buildCategoryCondition(filterInfo, category))
+                .fetchOne();
+    }
 }
 

--- a/src/main/java/com/fondant/product/presentation/ProductController.java
+++ b/src/main/java/com/fondant/product/presentation/ProductController.java
@@ -5,6 +5,7 @@ import com.fondant.global.dto.ResponseDto;
 import com.fondant.global.dto.SuccessMessage;
 import com.fondant.product.application.ProductService;
 import com.fondant.product.application.dto.FilterInfo;
+import com.fondant.product.application.dto.SortType;
 import com.fondant.product.presentation.dto.response.FilteredProductCountResponse;
 import com.fondant.product.presentation.dto.response.ProductDetailResponse;
 import com.fondant.product.presentation.dto.response.ProductsResponse;
@@ -64,10 +65,11 @@ public class ProductController {
             @RequestParam(name="categoryIds" ,required = false) List<Long> categoryIds,
             @RequestParam(name="packagingTypes", required = false) List<String> packagingTypes,
             @RequestParam(name="benefits", required = false) List<String> benefits,
+            @RequestParam(value = "sortType", required = false) Optional<SortType> sortType,
             @RequestParam(name="page") int page) {
         FilterInfo filterinfo = new FilterInfo(minPrice,maxPrice,categoryIds,packagingTypes,benefits);
 
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
-                productService.getFilteredProducts(filterinfo,pageConfig.customPageable(page))));
+                productService.getFilteredProducts(filterinfo,pageConfig.customPageable(page),sortType)));
     }
 }

--- a/src/main/java/com/fondant/product/presentation/ProductController.java
+++ b/src/main/java/com/fondant/product/presentation/ProductController.java
@@ -4,12 +4,15 @@ import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.ResponseDto;
 import com.fondant.global.dto.SuccessMessage;
 import com.fondant.product.application.ProductService;
+import com.fondant.product.application.dto.FilterInfo;
+import com.fondant.product.presentation.dto.response.FilteredProductCountResponse;
 import com.fondant.product.presentation.dto.response.ProductDetailResponse;
 import com.fondant.product.presentation.dto.response.ProductsResponse;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
 
 
 @RestController
@@ -39,5 +42,18 @@ public class ProductController {
             @PathVariable(name="productId") Long productId) {
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
                 productService.getProductDetail(productId)));
+    }
+
+    @GetMapping("/filter/count")
+    public ResponseEntity<ResponseDto<FilteredProductCountResponse>> getFilterCount(
+            @RequestParam Optional<Double> minPrice,
+            @RequestParam Optional<Double> maxPrice,
+            @RequestParam(required = false) List<Long> categoryIds,
+            @RequestParam(required = false) List<String> packagingTypes,
+            @RequestParam(required = false) List<String> benefits) {
+        FilterInfo filterinfo = new FilterInfo(minPrice,maxPrice,categoryIds,packagingTypes,benefits);
+
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                productService.getFilteredProductCounts(filterinfo)));
     }
 }

--- a/src/main/java/com/fondant/product/presentation/ProductController.java
+++ b/src/main/java/com/fondant/product/presentation/ProductController.java
@@ -46,14 +46,28 @@ public class ProductController {
 
     @GetMapping("/filter/count")
     public ResponseEntity<ResponseDto<FilteredProductCountResponse>> getFilterCount(
-            @RequestParam Optional<Double> minPrice,
-            @RequestParam Optional<Double> maxPrice,
-            @RequestParam(required = false) List<Long> categoryIds,
-            @RequestParam(required = false) List<String> packagingTypes,
-            @RequestParam(required = false) List<String> benefits) {
+            @RequestParam(name="minPrice") Optional<Double> minPrice,
+            @RequestParam(name="maxPrice") Optional<Double> maxPrice,
+            @RequestParam(name="categoryIds" ,required = false) List<Long> categoryIds,
+            @RequestParam(name="packagingTypes", required = false) List<String> packagingTypes,
+            @RequestParam(name="benefits", required = false) List<String> benefits) {
         FilterInfo filterinfo = new FilterInfo(minPrice,maxPrice,categoryIds,packagingTypes,benefits);
 
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
                 productService.getFilteredProductCounts(filterinfo)));
+    }
+
+    @GetMapping("/filter")
+    public ResponseEntity<ResponseDto<ProductsResponse>> getFilteredProducts(
+            @RequestParam(name="minPrice") Optional<Double> minPrice,
+            @RequestParam(name="maxPrice") Optional<Double> maxPrice,
+            @RequestParam(name="categoryIds" ,required = false) List<Long> categoryIds,
+            @RequestParam(name="packagingTypes", required = false) List<String> packagingTypes,
+            @RequestParam(name="benefits", required = false) List<String> benefits,
+            @RequestParam(name="page") int page) {
+        FilterInfo filterinfo = new FilterInfo(minPrice,maxPrice,categoryIds,packagingTypes,benefits);
+
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS,
+                productService.getFilteredProducts(filterinfo,pageConfig.customPageable(page))));
     }
 }

--- a/src/main/java/com/fondant/product/presentation/dto/response/FilteredProductCountResponse.java
+++ b/src/main/java/com/fondant/product/presentation/dto/response/FilteredProductCountResponse.java
@@ -1,0 +1,8 @@
+package com.fondant.product.presentation.dto.response;
+
+import com.fondant.product.application.dto.FilterInfo;
+
+public record FilteredProductCountResponse(
+        Long count
+) {
+}

--- a/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
@@ -334,6 +334,7 @@ public class ProductRestDocsTest {
                         .param("categoryIds", String.valueOf(category1.getId()))
                         .param("packingTypes", "box")
                         .param("benefitTypes", "free_shipping")
+                        .param("sortType", "PRICE_ASC")
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken))
@@ -347,6 +348,14 @@ public class ProductRestDocsTest {
                                 parameterWithName("categoryIds").optional().description("필터할 카테고리 ID 목록"),
                                 parameterWithName("packingTypes").optional().description("포장 타입 목록"),
                                 parameterWithName("benefitTypes").optional().description("혜택 타입 목록"),
+                                parameterWithName("sortType").optional().description(
+                                        "- DISCOUNT : 할인순 +" + "\n" +
+                                        "- REVIEW : 리뷰 많은순 +" + "\n" +
+                                        "- SALES : 판매량순 +" + "\n" +
+                                        "- PRICE_ASC : 낮은 가격순 +" + "\n" +
+                                        "- PRICE_DESC : 높은 가격순 +" + "\n" +
+                                        "※ 요청 시 위 enum 값을 그대로 입력해야 합니다."
+                                ),
                                 parameterWithName("page").description("요청 페이지 번호 (0부터 시작)")
                         ),
                         responseFields(

--- a/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
@@ -15,6 +15,7 @@ import com.fondant.user.domain.entity.SNSType;
 import com.fondant.user.domain.entity.UserEntity;
 import com.fondant.user.domain.entity.UserRole;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -292,5 +293,79 @@ public class ProductRestDocsTest {
                                 fieldWithPath("basePrice").description("상품 기본 가격 (옵션 가격 추가 전)"),
                         })));
     }
+
+    @Test
+    @DisplayName("상품 필터링 - 상품 수 조회 API")
+    void getFilteredProductCount() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/filter/count")
+                        .param("startPrice", "10000")
+                        .param("endPrice", "20000")
+                        .param("categoryIds", String.valueOf(category1.getId()))
+                        .param("packingTypes", "box")
+                        .param("benefitTypes", "free_shipping")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("products/get-filtered-product-count",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("startPrice").optional().description("가격 필터 최소값"),
+                                parameterWithName("endPrice").optional().description("가격 필터 최대값"),
+                                parameterWithName("categoryIds").optional().description("필터할 카테고리 ID 목록"),
+                                parameterWithName("packingTypes").optional().description("포장 타입 목록"),
+                                parameterWithName("benefitTypes").optional().description("혜택 타입 목록")
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
+                                fieldWithPath("count").description("필터링된 상품 개수")
+                        })
+                ));
+    }
+
+    @Test
+    @DisplayName("상품 필터링 - 상품 리스트 조회 API")
+    void getFilteredProducts() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/filter")
+                        .param("startPrice", "10000")
+                        .param("endPrice", "20000")
+                        .param("categoryIds", String.valueOf(category1.getId()))
+                        .param("packingTypes", "box")
+                        .param("benefitTypes", "free_shipping")
+                        .param("page", "0")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken))
+                .andExpect(status().isOk())
+                .andDo(document("products/get-filtered-products",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("startPrice").optional().description("가격 필터 최소값"),
+                                parameterWithName("endPrice").optional().description("가격 필터 최대값"),
+                                parameterWithName("categoryIds").optional().description("필터할 카테고리 ID 목록"),
+                                parameterWithName("packingTypes").optional().description("포장 타입 목록"),
+                                parameterWithName("benefitTypes").optional().description("혜택 타입 목록"),
+                                parameterWithName("page").description("요청 페이지 번호 (0부터 시작)")
+                        ),
+                        responseFields(
+                                commonResponseFields()
+                        ).andWithPrefix("response.", new FieldDescriptor[]{
+                                fieldWithPath("pageInfo.currentPage").description("현재 페이지 번호"),
+                                fieldWithPath("pageInfo.totalPage").description("총 페이지 수"),
+                                fieldWithPath("products").description("상품 목록"),
+                                fieldWithPath("products[].id").description("상품 ID"),
+                                fieldWithPath("products[].name").description("상품 이름"),
+                                fieldWithPath("products[].price").description("상품 가격"),
+                                fieldWithPath("products[].score").description("리뷰 평점"),
+                                fieldWithPath("products[].thumbnailUrl").description("상품 썸네일 URL"),
+                                fieldWithPath("products[].discountRate").description("상품 할인율"),
+                                fieldWithPath("products[].discountPrice").description("상품 할인 후 가격")
+                        })
+                ));
+    }
+
+
 }
 

--- a/src/test/java/com/fondant/unit/ProductFilterServiceTest.java
+++ b/src/test/java/com/fondant/unit/ProductFilterServiceTest.java
@@ -10,11 +10,14 @@ import com.fondant.product.domain.entity.ProductCategoryEntity;
 import com.fondant.product.domain.entity.ProductEntity;
 import com.fondant.product.domain.repository.ProductCategoryRepository;
 import com.fondant.product.domain.repository.ProductRepository;
+import com.fondant.product.presentation.dto.response.ProductsResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -227,6 +230,34 @@ public class ProductFilterServiceTest{
 
         // then
         assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("가격 + 포장타입 + 혜택 + 카테고리 조건 조합으로 상품 조회 테스트")
+    void getFilteredProducts_withMultipleConditions_success() {
+        // given
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.of(10000.0),
+                Optional.of(13000.0),
+                List.of(category1.getId()),
+                List.of("box"),
+                List.of("free_shipping")
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        ProductsResponse response = productFilterService.getFilteredProducts(filterInfo, pageable);
+
+        // then
+        assertThat(response.pageInfo()).isNotNull();
+        assertThat(response.pageInfo().currentPage()).isEqualTo(0);
+        assertThat(response.pageInfo().totalPage()).isEqualTo(1);
+
+        assertThat(response.products().size()).isEqualTo(1);
+        assertThat(response.products().get(0).name()).isEqualTo("다크초콜릿 바");
+
+
     }
 
 }

--- a/src/test/java/com/fondant/unit/ProductFilterServiceTest.java
+++ b/src/test/java/com/fondant/unit/ProductFilterServiceTest.java
@@ -1,0 +1,232 @@
+package com.fondant.unit;
+
+import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.market.domain.repository.MarketRepository;
+import com.fondant.product.application.ProductService;
+import com.fondant.product.application.dto.FilterInfo;
+import com.fondant.product.category.domain.CategoryEntity;
+import com.fondant.product.category.domain.repository.CategoryRepository;
+import com.fondant.product.domain.entity.ProductCategoryEntity;
+import com.fondant.product.domain.entity.ProductEntity;
+import com.fondant.product.domain.repository.ProductCategoryRepository;
+import com.fondant.product.domain.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@Transactional
+@DisplayName("상품 필터링 카운트 테스트")
+public class ProductFilterServiceTest{
+    @Autowired
+    private ProductService productFilterService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private MarketRepository marketRepository;
+
+    @Autowired
+    private ProductCategoryRepository productCategoryRepository;
+
+    private MarketEntity market;
+    private CategoryEntity category1;
+    private CategoryEntity category2;
+    private ProductEntity product1;
+    private ProductEntity product2;
+
+    @BeforeEach
+    void setUp() {
+        // 마켓 생성
+        market = createMarket();
+
+        // 대분류 및 소분류 카테고리 생성
+        category1 = createCategoryWithSubCategories("초콜릿", "domain/icon/chocolate", List.of("다크초콜릿", "화이트초콜릿"));
+        category2 = createCategoryWithSubCategories("쿠키", "domain/icon/cookie", List.of("르뱅쿠키", "비건쿠키"));
+
+        // 상품 생성
+        product1 = createProduct("다크초콜릿 바", 12000, "box", "free_shipping", market);
+        product2 = createProduct("르뱅 쿠키", 8000, "bag", "discount", market);
+
+        // 상품과 소분류 연결
+        linkProductToSubCategory(product1, category1.getChildren().get(0)); // 다크초콜릿
+        linkProductToSubCategory(product2, category2.getChildren().get(0)); // 르뱅쿠키
+    }
+
+    private MarketEntity createMarket() {
+        return marketRepository.save(MarketEntity.builder()
+                .name("테스트 마켓")
+                .description("테스트용 마켓입니다.")
+                .thumbnail("test-market-thumbnail.png")
+                .background("test-market-background.png")
+                .totalSales(0L)
+                .totalReviews(0L)
+                .build());
+    }
+
+    private CategoryEntity createCategoryWithSubCategories(String mainCategoryName, String iconUrl, List<String> subCategoryNames) {
+        CategoryEntity mainCategory = CategoryEntity.builder()
+                .name(mainCategoryName)
+                .iconUrl(iconUrl)
+                .build();
+
+        for (String subName : subCategoryNames) {
+            mainCategory.addChild(CategoryEntity.builder()
+                    .name(subName)
+                    .build());
+        }
+
+        return categoryRepository.save(mainCategory);
+    }
+
+    private ProductEntity createProduct(String name, int price, String packagingType, String benefit, MarketEntity market) {
+        return productRepository.save(ProductEntity.builder()
+                .name(name)
+                .description(name + " 설명입니다.")
+                .thumbnail("product-thumbnail.png")
+                .price(price)
+                .market(market)
+                .startDate(LocalDate.of(2025, 1, 1))
+                .maxCount(100)
+                //.packagingType(packagingType)
+                //.benefit(benefit)
+                .build());
+    }
+
+    private void linkProductToSubCategory(ProductEntity product, CategoryEntity subCategory) {
+        productCategoryRepository.save(ProductCategoryEntity.builder()
+                .product(product)
+                .category(subCategory)
+                .build());
+    }
+
+    @Test
+    @DisplayName("가격 범위로 상품 수 필터링")
+    void countProductsByPriceFilter_success() {
+        // given
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.of(10000.0),
+                Optional.of(13000.0),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+
+        // when
+        Long count = productFilterService.getFilteredProductCounts(filterInfo).count();
+
+        // then
+        assertThat(count).isEqualTo(1L);
+    }
+
+    // 사용예정 : 포장타입 및 혜택 추가 예정
+    /*
+    @Test
+    @DisplayName("포장 타입으로 상품 수 필터링")
+    void countProductsByPackagingTypeFilter_success() {
+        // given
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                List.of("bag"),
+                List.of()
+        );
+
+        // when
+        Long count = productFilterService.getFilteredProductCounts(filterInfo).count();
+
+        // then
+        assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("혜택으로 상품 수 필터링")
+    void countProductsByBenefitFilter_success() {
+        // given
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                List.of(),
+                List.of("free_shipping")
+        );
+
+        // when
+        Long count = productFilterService.getFilteredProductCounts(filterInfo).count();
+
+        // then
+        assertThat(count).isEqualTo(1L);
+    }
+*/
+    @Test
+    @DisplayName("대분류 카테고리로 상품 수 필터링")
+    void countProductsByMainCategoryFilter_success() {
+        // given
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.empty(),
+                Optional.empty(),
+                List.of(category1.getId()),
+                List.of(),
+                List.of()
+        );
+
+        // when
+        Long count = productFilterService.getFilteredProductCounts(filterInfo).count();
+
+        // then
+        assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("모든 조건 없이 전체 상품 수 필터링")
+    void countAllProducts_success() {
+        // given
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+
+        // when
+        Long count = productFilterService.getFilteredProductCounts(filterInfo).count();
+
+        // then
+        assertThat(count).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("가격 + 포장타입 + 혜택 + 카테고리 조건 조합 필터링")
+    void countProductsByMultipleFilters_success() {
+        // given
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.of(10000.0),
+                Optional.of(13000.0),
+                List.of(category1.getId()),
+                List.of("box"),
+                List.of("free_shipping")
+        );
+
+        // when
+        Long count = productFilterService.getFilteredProductCounts(filterInfo).count();
+
+        // then
+        assertThat(count).isEqualTo(1L);
+    }
+
+}

--- a/src/test/java/com/fondant/unit/ProductFilterServiceTest.java
+++ b/src/test/java/com/fondant/unit/ProductFilterServiceTest.java
@@ -4,6 +4,7 @@ import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.market.domain.repository.MarketRepository;
 import com.fondant.product.application.ProductService;
 import com.fondant.product.application.dto.FilterInfo;
+import com.fondant.product.application.dto.SortType;
 import com.fondant.product.category.domain.CategoryEntity;
 import com.fondant.product.category.domain.repository.CategoryRepository;
 import com.fondant.product.domain.entity.ProductCategoryEntity;
@@ -50,6 +51,7 @@ public class ProductFilterServiceTest{
     private CategoryEntity category2;
     private ProductEntity product1;
     private ProductEntity product2;
+    private ProductEntity product3;
 
     @BeforeEach
     void setUp() {
@@ -245,9 +247,10 @@ public class ProductFilterServiceTest{
         );
 
         Pageable pageable = PageRequest.of(0, 10);
+        SortType sortType = SortType.REVIEW;
 
         // when
-        ProductsResponse response = productFilterService.getFilteredProducts(filterInfo, pageable);
+        ProductsResponse response = productFilterService.getFilteredProducts(filterInfo, pageable,Optional.of(sortType));
 
         // then
         assertThat(response.pageInfo()).isNotNull();
@@ -257,7 +260,64 @@ public class ProductFilterServiceTest{
         assertThat(response.products().size()).isEqualTo(1);
         assertThat(response.products().get(0).name()).isEqualTo("다크초콜릿 바");
 
-
     }
+
+    @Test
+    @DisplayName("가격 낮은순 정렬 테스트")
+    void getFilteredProducts_sortByPriceAsc_success() {
+        // given
+        product3 = createProduct("비건 쿠키", 15000, "bag", "discount", market);
+        linkProductToSubCategory(product3, category2.getChildren().get(1));
+
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        ProductsResponse response = productFilterService.getFilteredProducts(filterInfo, pageable,Optional.of(SortType.PRICE_ASC));
+
+        // then
+        assertThat(response.products().get(0).name()).isEqualTo("르뱅 쿠키");
+        assertThat(response.products().get(1).name()).isEqualTo("다크초콜릿 바");
+        assertThat(response.products().get(2).name()).isEqualTo("비건 쿠키");
+    }
+
+    @Test
+    @DisplayName("할인율 높은순 정렬 테스트")
+    void getFilteredProducts_sortByDiscount_success() {
+        // given
+        product3 = createProduct("비건 쿠키", 15000, "bag", "discount", market);
+        linkProductToSubCategory(product3, category2.getChildren().get(1));
+
+        product1.updateDiscountRate(0.0);
+        product2.updateDiscountRate(1.0);
+        product3.updateDiscountRate(2.0);
+
+
+        FilterInfo filterInfo = new FilterInfo(
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        ProductsResponse response = productFilterService.getFilteredProducts(filterInfo, pageable,Optional.of(SortType.DISCOUNT));
+
+        // then
+        assertThat(response.products().get(0).name()).isEqualTo("비건 쿠키");
+        assertThat(response.products().get(1).name()).isEqualTo("르뱅 쿠키");
+        assertThat(response.products().get(2).name()).isEqualTo("다크초콜릿 바");
+    }
+
 
 }


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- #62 
## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
### 필터링 항목에 따른 상품 개수 조회
우선 필터를 최종적용하기 전에 상품 개수를 업데이트해서 UI에 보여주고 있기 때문에 개수만 쿼리로 구해서 반환합니다.
<img width="505" alt="image" src="https://github.com/user-attachments/assets/c8a7f6d8-3b52-40d2-bbb4-21b8a791527f" />

### 필터링 항목에 따른 상품 목록 조회
최종 필터가 들어오면 해당 상품들을 조회해서 목록을 반환합니다.
- `BooleanBuilder` : 데이터베이스 쿼리를 동적으로 생성하기 위해 사용
    최종 필터 조건을 받아 해당 조건에 맞는 상품 목록을 조회합니다. 상품 내 필드에 대한 조건은 BooleanBuilder를 사용해 동적으로 구성하며, 조인 조건 외의 필터는 모두 builder로 묶어 where 절에 적용되기 때문에 메인 쿼리 로직을 깔끔하게 유지할 수 있습니다.
<img width="505" alt="image" src="https://github.com/user-attachments/assets/42151d9a-cb85-47e8-b795-5ee8c2bcf17c" />

### 상품 정렬
필터 조건 외에 SortType 파라미터를 받아 정렬 기준에 따라 상품 목록을 정렬합니다.
가격 정렬은 price 필드를 기준으로 asc 또는 desc 정렬하며,
할인순 정렬은 discountRate 필드를 기준으로 내림차순 정렬합니다.
정렬 조건은 Optional<SortType>을 받아 동적으로 적용됩니다.

## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
- packingType(포장타입), benefitTypes(혜택타입)이 모호해서 우선 추가해두지 않았는데 이건 엔티티 속성만 추가하면 바로 사용가능하도록 주석처리 해놓았습니다. 참고부탁드립니다.

- 정렬 조건중에 리뷰수랑 판매량도 판매로그 테이블이랑 리뷰테이블 구현전이라 그냥 두었습니다.