### PR TITLE
[Fix] 마켓/카테고리별 상품목록 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/fondant/market/application/dto/MarketInfoForProductDetail.java
+++ b/src/main/java/com/fondant/market/application/dto/MarketInfoForProductDetail.java
@@ -10,6 +10,6 @@ public record MarketInfoForProductDetail(
         Long totalReviews,
         String description,
         String thumbnail,
-        Long freeDeliveryLimit
+        Double freeDeliveryLimit
 ) {
 }

--- a/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/fondant/product/domain/repository/ProductRepositoryImpl.java
@@ -22,15 +22,9 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long mainCategoryId, Pageable pageable) {
-        List<Long> subCategoryIds = findSubCategoryIdsByMainCategory(mainCategoryId);
-
-        if (subCategoryIds.isEmpty()) {
-            return Page.empty(pageable);
-        }
-
-        List<ProductEntity> content = findProductsByMarketAndSubCategories(marketId, subCategoryIds, pageable);
-        Long total = countProductsByMarketAndSubCategories(marketId, subCategoryIds);
+    public Page<ProductEntity> findProductsByMarketAndCategory(Long marketId, Long subCategoryId, Pageable pageable) {
+        List<ProductEntity> content = findProductsByMarketAndSubCategory(marketId, subCategoryId, pageable);
+        Long total = countProductsByMarketAndSubCategory(marketId, subCategoryId);
 
         return new PageImpl<>(content, pageable, total != null ? total : 0);
     }
@@ -44,6 +38,43 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .where(category.parent.id.eq(mainCategoryId))
                 .fetch();
     }
+
+    private List<ProductEntity> findProductsByMarketAndSubCategory(Long marketId, Long subCategoryId, Pageable pageable) {
+        QProductEntity product = QProductEntity.productEntity;
+        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        return queryFactory
+                .selectDistinct(product)
+                .from(product)
+                .join(productCategory).on(product.eq(productCategory.product))
+                .join(productCategory.category, category)
+                .where(
+                        product.market.id.eq(marketId),
+                        category.id.eq(subCategoryId)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private Long countProductsByMarketAndSubCategory(Long marketId, Long subCategoryId) {
+        QProductEntity product = QProductEntity.productEntity;
+        QProductCategoryEntity productCategory = QProductCategoryEntity.productCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        return queryFactory
+                .select(product.countDistinct())
+                .from(product)
+                .join(productCategory).on(product.eq(productCategory.product))
+                .join(productCategory.category, category)
+                .where(
+                        product.market.id.eq(marketId),
+                        category.id.eq(subCategoryId)
+                )
+                .fetchOne();
+    }
+
 
     private List<ProductEntity> findProductsByMarketAndSubCategories(Long marketId, List<Long> subCategoryIds, Pageable pageable) {
         QProductEntity product = QProductEntity.productEntity;

--- a/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/ProductRestDocsTest.java
@@ -223,7 +223,7 @@ public class ProductRestDocsTest {
 
     @Test
     void getProductsByMarketAndCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/{marketId}/{categoryId}", market.getId(), category1.getId())
+        mockMvc.perform(get(BASE_URL + "/{marketId}/{categoryId}", market.getId(), category1.getChildren().get(1).getId())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/fondant/restdocs/WishListRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/WishListRestDocsTest.java
@@ -130,7 +130,7 @@ public class WishListRestDocsTest {
                 .name("두바이 초콜릿")
                 .description("카다이프 듬뿍 두바이 초콜릿입니다.")
                 .thumbnail("product-thumbnail.png")
-                .price(15000)
+                .price(15000.0)
                 .market(market)
                 .startDate(LocalDate.of(2025, 1, 1))
                 .maxCount(50)
@@ -140,7 +140,7 @@ public class WishListRestDocsTest {
                 .name("헤이즐넛 쿠키")
                 .description("헤이즐넛 쿠키 입니다.")
                 .thumbnail("product-thumbnail.png")
-                .price(15000)
+                .price(15000.0)
                 .market(market)
                 .startDate(LocalDate.of(2025, 1, 1))
                 .maxCount(50)
@@ -167,7 +167,7 @@ public class WishListRestDocsTest {
                 OptionEntity.builder()
                         .name("3개 세트")
                         .productId(product1.getId())
-                        .price(20000)
+                        .price(20000.0)
                         .build());
 
         testUser = userRepository.save(


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- #74 
## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
마켓/카테고리별 상품목록조회 기준이 메인->서브로 변경됨에 따라 쿼리를 수정하였습니다.

## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
우선 기존에 메인카테고리로 상품목록 조회하던 쿼리는 그대로 두고 서브 카테고리로 상품목록 조회하도록 수정하였습니다.
