### PR TITLE
[Fix] 장바구니 응답 구조 수정

### DIFF
--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -73,11 +73,8 @@ public class CartService {
                         .productName(item.getProduct().getName())
                         .thumbnail(item.getProduct().getThumbnail())
                         .options(optionInfos)
-                        .totalQuantity(totalQuantity)
+                        .quantity(item.getQuantity())
                         .arrivalDate(item.getArrivalDate())
-                        .totalProductPrice(totalProductPrice)
-                        .deliveryFee(deliveryFee)
-                        .finalPrice(finalPrice)
                         .build();
 
                 products.add(productInfo);

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -72,6 +72,7 @@ public class CartService {
                         .productId(item.getProduct().getId())
                         .productName(item.getProduct().getName())
                         .thumbnail(item.getProduct().getThumbnail())
+                        .basePrice(item.getProduct().getPrice())
                         .options(optionInfos)
                         .quantity(item.getQuantity())
                         .arrivalDate(item.getArrivalDate())

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -40,6 +40,7 @@ public class CartService {
             List<CartItemEntity> itemsInMarket = entry.getValue();
             String marketName = itemsInMarket.get(0).getCartMarket().getMarket().getName();
 
+            double freeDeliveryLimit = itemsInMarket.get(0).getCartMarket().getMarket().getFreeDeliveryLimit();
             List<CartProductInfo> products = new ArrayList<>();
 
             for (CartItemEntity item : itemsInMarket) {
@@ -84,6 +85,7 @@ public class CartService {
             CartMarketInfo marketInfo = CartMarketInfo.builder()
                     .marketId(marketId)
                     .marketName(marketName)
+                    .freeDeliveryLimit(freeDeliveryLimit)
                     .products(products)
                     .build();
 

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -39,7 +39,6 @@ public class CartService {
             Long marketId = entry.getKey();
             List<CartItemEntity> itemsInMarket = entry.getValue();
             String marketName = itemsInMarket.get(0).getCartMarket().getMarket().getName();
-
             double freeDeliveryLimit = itemsInMarket.get(0).getCartMarket().getMarket().getFreeDeliveryLimit();
             List<CartProductInfo> products = new ArrayList<>();
 
@@ -55,19 +54,7 @@ public class CartService {
                                 .build())
                         .collect(Collectors.toList());
 
-                int totalQuantity = optionInfos.stream()
-                        .mapToInt(CartOptionInfo::quantity)
-                        .sum();
-
-                Double totalOptionPrice = optionInfos.stream()
-                        .mapToDouble(opt -> opt.additionalPrice() * opt.quantity())
-                        .sum();
-
                 Double basePrice = (double) item.getProduct().getPrice();
-                Double totalProductPrice = basePrice * totalQuantity + totalOptionPrice;
-
-                Double deliveryFee = Optional.ofNullable(item.getCartMarket().getMarket().getDeliveryFee()).orElse(0.0);
-                Double finalPrice = totalProductPrice + deliveryFee;
 
                 CartProductInfo productInfo = CartProductInfo.builder()
                         .productId(item.getProduct().getId())

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -33,52 +33,54 @@ public class CartService {
         Map<Long, List<CartItemEntity>> marketGrouped = cartItems.stream()
                 .collect(Collectors.groupingBy(item -> item.getCartMarket().getMarket().getId()));
 
-        List<CartMarketInfo> markets = new ArrayList<>();
-
-        for (Map.Entry<Long, List<CartItemEntity>> entry : marketGrouped.entrySet()) {
-            Long marketId = entry.getKey();
-            List<CartItemEntity> itemsInMarket = entry.getValue();
-            String marketName = itemsInMarket.get(0).getCartMarket().getMarket().getName();
-            double freeDeliveryLimit = itemsInMarket.get(0).getCartMarket().getMarket().getFreeDeliveryLimit();
-            List<CartProductInfo> products = new ArrayList<>();
-
-            for (CartItemEntity item : itemsInMarket) {
-                List<CartOptionInfo> optionInfos = Optional.ofNullable(item.getCartItemOptions())
-                        .orElse(Collections.emptyList())
-                        .stream()
-                        .map(opt -> CartOptionInfo.builder()
-                                .optionId(opt.getOption().getId())
-                                .optionName(opt.getOption().getName())
-                                .additionalPrice((double) opt.getOption().getPrice())
-                                .quantity(opt.getQuantity())
-                                .build())
-                        .collect(Collectors.toList());
-
-                Double basePrice = (double) item.getProduct().getPrice();
-
-                CartProductInfo productInfo = CartProductInfo.builder()
-                        .productId(item.getProduct().getId())
-                        .productName(item.getProduct().getName())
-                        .thumbnail(item.getProduct().getThumbnail())
-                        .basePrice(item.getProduct().getPrice())
-                        .options(optionInfos)
-                        .quantity(item.getQuantity())
-                        .arrivalDate(item.getArrivalDate())
-                        .build();
-
-                products.add(productInfo);
-            }
-
-            CartMarketInfo marketInfo = CartMarketInfo.builder()
-                    .marketId(marketId)
-                    .marketName(marketName)
-                    .freeDeliveryLimit(freeDeliveryLimit)
-                    .products(products)
-                    .build();
-
-            markets.add(marketInfo);
-        }
+        List<CartMarketInfo> markets = toCartMarketInfoList(marketGrouped);
 
         return CartResponse.of(markets, PageInfo.of(page.getNumber(), page.getTotalPages()));
+    }
+
+    private List<CartMarketInfo> toCartMarketInfoList(Map<Long, List<CartItemEntity>> marketGrouped) {
+        return marketGrouped.entrySet().stream()
+                .map(entry -> {
+                    Long marketId = entry.getKey();
+                    List<CartItemEntity> items = entry.getValue();
+                    var market = items.get(0).getCartMarket().getMarket();
+
+                    List<CartProductInfo> products = toCartProductInfoList(items);
+
+                    return CartMarketInfo.builder()
+                            .marketId(marketId)
+                            .marketName(market.getName())
+                            .freeDeliveryLimit(market.getFreeDeliveryLimit())
+                            .products(products)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<CartProductInfo> toCartProductInfoList(List<CartItemEntity> items) {
+        return items.stream()
+                .map(item -> {
+                    List<CartOptionInfo> options = Optional.ofNullable(item.getCartItemOptions())
+                            .orElse(Collections.emptyList())
+                            .stream()
+                            .map(opt -> CartOptionInfo.builder()
+                                    .optionId(opt.getOption().getId())
+                                    .optionName(opt.getOption().getName())
+                                    .additionalPrice((double) opt.getOption().getPrice())
+                                    .quantity(opt.getQuantity())
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    return CartProductInfo.builder()
+                            .productId(item.getProduct().getId())
+                            .productName(item.getProduct().getName())
+                            .thumbnail(item.getProduct().getThumbnail())
+                            .basePrice(item.getProduct().getPrice())
+                            .options(options)
+                            .quantity(item.getQuantity())
+                            .arrivalDate(item.getArrivalDate())
+                            .build();
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/fondant/cart/application/dto/CartMarketInfo.java
+++ b/src/main/java/com/fondant/cart/application/dto/CartMarketInfo.java
@@ -8,5 +8,6 @@ import java.util.List;
 public record CartMarketInfo (
         Long marketId,
         String marketName,
+        Double freeDeliveryLimit,
         List<CartProductInfo> products
 ) {}

--- a/src/main/java/com/fondant/cart/application/dto/CartProductInfo.java
+++ b/src/main/java/com/fondant/cart/application/dto/CartProductInfo.java
@@ -11,9 +11,6 @@ public record CartProductInfo (
         String productName,
         String thumbnail,
         List<CartOptionInfo> options,
-        int totalQuantity,
-        LocalDate arrivalDate,
-        Double totalProductPrice,
-        Double deliveryFee,
-        Double finalPrice
+        int quantity,
+        LocalDate arrivalDate
 ) {}

--- a/src/main/java/com/fondant/cart/application/dto/CartProductInfo.java
+++ b/src/main/java/com/fondant/cart/application/dto/CartProductInfo.java
@@ -10,6 +10,7 @@ public record CartProductInfo (
         Long productId,
         String productName,
         String thumbnail,
+        Double basePrice,
         List<CartOptionInfo> options,
         int quantity,
         LocalDate arrivalDate

--- a/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
@@ -92,7 +92,7 @@ public class CartRestDocsTest {
                         .name("쫀득쿠키")
                         .description("옵션이 없는 상품입니다.")
                         .thumbnail("thumbnail.jpg")
-                        .price(5000)
+                        .price(5000.0)
                         .market(market)
                         .startDate(LocalDate.now())
                         .build()
@@ -103,7 +103,7 @@ public class CartRestDocsTest {
                         .name("딸기모찌")
                         .description("옵션이 있는 상품입니다.")
                         .thumbnail("thumbnail.jpg")
-                        .price(8000)
+                        .price(8000.0)
                         .market(market)
                         .startDate(LocalDate.now())
                         .build()
@@ -112,7 +112,7 @@ public class CartRestDocsTest {
         OptionEntity option1 = optionRepository.save(
                 OptionEntity.builder()
                         .name("3개 세트")
-                        .price(2000)
+                        .price(2000.0)
                         .productId(product2.getId())
                         .build()
         );
@@ -120,7 +120,7 @@ public class CartRestDocsTest {
         OptionEntity option2 = optionRepository.save(
                 OptionEntity.builder()
                         .name("5개 세트")
-                        .price(3000)
+                        .price(3000.0)
                         .productId(product2.getId())
                         .build()
         );
@@ -179,7 +179,7 @@ public class CartRestDocsTest {
         return new FieldDescriptor[]{
                 fieldWithPath("code").description("요청 성공 여부"),
                 fieldWithPath("message").description("응답 메시지"),
-                fieldWithPath("response").description("응답 데이터")
+                fieldWithPath("content").description("응답 데이터")
         };
     }
 
@@ -196,7 +196,7 @@ public class CartRestDocsTest {
                         preprocessResponse(prettyPrint()),
                         responseFields(
                                 commonResponseFields()
-                        ).andWithPrefix("response.", new FieldDescriptor[] {
+                        ).andWithPrefix("content.", new FieldDescriptor[] {
                                 fieldWithPath("pageInfo").description("페이지 정보"),
                                 fieldWithPath("pageInfo.currentPage").description("현재 페이지 번호"),
                                 fieldWithPath("pageInfo.totalPage").description("총 페이지 수"),
@@ -206,16 +206,13 @@ public class CartRestDocsTest {
                                 fieldWithPath("markets[].products[].productId").description("상품 ID"),
                                 fieldWithPath("markets[].products[].productName").description("상품 이름"),
                                 fieldWithPath("markets[].products[].thumbnail").description("상품 썸네일 URL"),
-                                fieldWithPath("markets[].products[].options").description("옵션 목록 (없으면 빈 배열)").type(ARRAY).optional(),
+                                fieldWithPath("markets[].products[].quantity").description("상품 수량"),
+                                fieldWithPath("markets[].products[].arrivalDate").description("도착 예정일"),
+                                fieldWithPath("markets[].products[].options").description("옵션 목록 (없으면 빈 배열)").type(JsonFieldType.ARRAY).optional(),
                                 fieldWithPath("markets[].products[].options[].optionId").type(JsonFieldType.NUMBER).description("옵션 ID"),
                                 fieldWithPath("markets[].products[].options[].optionName").type(JsonFieldType.STRING).description("옵션 이름"),
                                 fieldWithPath("markets[].products[].options[].additionalPrice").type(JsonFieldType.NUMBER).description("옵션 추가 금액"),
-                                fieldWithPath("markets[].products[].options[].quantity").type(JsonFieldType.NUMBER).description("옵션 수량"),
-                                fieldWithPath("markets[].products[].totalQuantity").description("상품 총 수량"),
-                                fieldWithPath("markets[].products[].arrivalDate").description("도착 예정일"),
-                                fieldWithPath("markets[].products[].totalProductPrice").description("상품 총 가격"),
-                                fieldWithPath("markets[].products[].deliveryFee").description("배송비"),
-                                fieldWithPath("markets[].products[].finalPrice").description("최종 결제 금액")
+                                fieldWithPath("markets[].products[].options[].quantity").type(JsonFieldType.NUMBER).description("옵션 수량")
                         })));
     }
 }

--- a/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
@@ -83,6 +83,7 @@ public class CartRestDocsTest {
                         .name("달미롱")
                         .thumbnail("thumbnail.jpg")
                         .background("bg.jpg")
+                        .freeDeliveryLimit(3500.0)
                         .deliveryFee(3000.0)
                         .build()
         );
@@ -202,6 +203,7 @@ public class CartRestDocsTest {
                                 fieldWithPath("pageInfo.totalPage").description("총 페이지 수"),
                                 fieldWithPath("markets[].marketId").description("마켓 ID"),
                                 fieldWithPath("markets[].marketName").description("마켓 이름"),
+                                fieldWithPath("markets[].freeDeliveryLimit").description("해당 마켓의 무료 배송 기준 금액"),
                                 fieldWithPath("markets[].products").description("상품 목록"),
                                 fieldWithPath("markets[].products[].productId").description("상품 ID"),
                                 fieldWithPath("markets[].products[].productName").description("상품 이름"),

--- a/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
@@ -205,6 +205,7 @@ public class CartRestDocsTest {
                                 fieldWithPath("markets[].products").description("상품 목록"),
                                 fieldWithPath("markets[].products[].productId").description("상품 ID"),
                                 fieldWithPath("markets[].products[].productName").description("상품 이름"),
+                                fieldWithPath("markets[].products[].basePrice").description("상품 기본 가격"),
                                 fieldWithPath("markets[].products[].thumbnail").description("상품 썸네일 URL"),
                                 fieldWithPath("markets[].products[].quantity").description("상품 수량"),
                                 fieldWithPath("markets[].products[].arrivalDate").description("도착 예정일"),

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,7 +31,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureRestDocs
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs(uriScheme = "http", uriHost = "localhost", uriPort = 8080)
 


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- closed #78 
## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
프론트측 요구사항에 맞게 장바구니 응답 구조를 수정했습니다.
### 1️⃣ 필드 수정
- total 계산 관련 필드 삭제
- 상품의 basePrice 필드 추가
- 마켓의 freeDeliveryLimit 필드 추가
### 2️⃣ 서비스 로직 삭제
- total 계산 관련 로직 삭제

### 3️⃣ restdocs
<img width="500" alt="스크린샷 2025-06-08 오후 5 58 50" src="https://github.com/user-attachments/assets/aa0b1200-591d-4184-997e-1c1d63ebcbda" />

**[프론트측 장바구니 데이터](https://github.com/GDG-PKNU-Fondant/fondant-frontend/commit/742afcc22ff94f7112a25c3af22f39045078ec91)**
selected 필드는 제외했습니다.

## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
테스트에서 response -> content로도 수정했습니다
