### PR TITLE
[Refactor] 장바구니 서비스 로직 책임 분리 및 가독성 개선

### DIFF
--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -33,52 +33,54 @@ public class CartService {
         Map<Long, List<CartItemEntity>> marketGrouped = cartItems.stream()
                 .collect(Collectors.groupingBy(item -> item.getCartMarket().getMarket().getId()));
 
-        List<CartMarketInfo> markets = new ArrayList<>();
-
-        for (Map.Entry<Long, List<CartItemEntity>> entry : marketGrouped.entrySet()) {
-            Long marketId = entry.getKey();
-            List<CartItemEntity> itemsInMarket = entry.getValue();
-            String marketName = itemsInMarket.get(0).getCartMarket().getMarket().getName();
-            double freeDeliveryLimit = itemsInMarket.get(0).getCartMarket().getMarket().getFreeDeliveryLimit();
-            List<CartProductInfo> products = new ArrayList<>();
-
-            for (CartItemEntity item : itemsInMarket) {
-                List<CartOptionInfo> optionInfos = Optional.ofNullable(item.getCartItemOptions())
-                        .orElse(Collections.emptyList())
-                        .stream()
-                        .map(opt -> CartOptionInfo.builder()
-                                .optionId(opt.getOption().getId())
-                                .optionName(opt.getOption().getName())
-                                .additionalPrice((double) opt.getOption().getPrice())
-                                .quantity(opt.getQuantity())
-                                .build())
-                        .collect(Collectors.toList());
-
-                Double basePrice = (double) item.getProduct().getPrice();
-
-                CartProductInfo productInfo = CartProductInfo.builder()
-                        .productId(item.getProduct().getId())
-                        .productName(item.getProduct().getName())
-                        .thumbnail(item.getProduct().getThumbnail())
-                        .basePrice(item.getProduct().getPrice())
-                        .options(optionInfos)
-                        .quantity(item.getQuantity())
-                        .arrivalDate(item.getArrivalDate())
-                        .build();
-
-                products.add(productInfo);
-            }
-
-            CartMarketInfo marketInfo = CartMarketInfo.builder()
-                    .marketId(marketId)
-                    .marketName(marketName)
-                    .freeDeliveryLimit(freeDeliveryLimit)
-                    .products(products)
-                    .build();
-
-            markets.add(marketInfo);
-        }
+        List<CartMarketInfo> markets = toCartMarketInfoList(marketGrouped);
 
         return CartResponse.of(markets, PageInfo.of(page.getNumber(), page.getTotalPages()));
+    }
+
+    private List<CartMarketInfo> toCartMarketInfoList(Map<Long, List<CartItemEntity>> marketGrouped) {
+        return marketGrouped.entrySet().stream()
+                .map(entry -> {
+                    Long marketId = entry.getKey();
+                    List<CartItemEntity> items = entry.getValue();
+                    var market = items.get(0).getCartMarket().getMarket();
+
+                    List<CartProductInfo> products = toCartProductInfoList(items);
+
+                    return CartMarketInfo.builder()
+                            .marketId(marketId)
+                            .marketName(market.getName())
+                            .freeDeliveryLimit(market.getFreeDeliveryLimit())
+                            .products(products)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<CartProductInfo> toCartProductInfoList(List<CartItemEntity> items) {
+        return items.stream()
+                .map(item -> {
+                    List<CartOptionInfo> options = Optional.ofNullable(item.getCartItemOptions())
+                            .orElse(Collections.emptyList())
+                            .stream()
+                            .map(opt -> CartOptionInfo.builder()
+                                    .optionId(opt.getOption().getId())
+                                    .optionName(opt.getOption().getName())
+                                    .additionalPrice((double) opt.getOption().getPrice())
+                                    .quantity(opt.getQuantity())
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    return CartProductInfo.builder()
+                            .productId(item.getProduct().getId())
+                            .productName(item.getProduct().getName())
+                            .thumbnail(item.getProduct().getThumbnail())
+                            .basePrice(item.getProduct().getPrice())
+                            .options(options)
+                            .quantity(item.getQuantity())
+                            .arrivalDate(item.getArrivalDate())
+                            .build();
+                })
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- closes #88

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
기존 CartService 클래스 내부에 dto 변환 로직이 모두 집중되어 있어서 상품/옵션/마켓 정보를 만드는 로직을 메서드로 분리하고 스트림 기반 처리 방식으로 개선했습니다.
```java
private List<CartMarketInfo> toCartMarketInfoList(Map<Long, List<CartItemEntity>> marketGrouped) {
        return marketGrouped.entrySet().stream()
                .map(entry -> {
                    Long marketId = entry.getKey();
                    List<CartItemEntity> items = entry.getValue();
                    var market = items.get(0).getCartMarket().getMarket();

                    List<CartProductInfo> products = toCartProductInfoList(items);

                    return CartMarketInfo.builder()
                            .marketId(marketId)
                            .marketName(market.getName())
                            .freeDeliveryLimit(market.getFreeDeliveryLimit())
                            .products(products)
                            .build();
                })
                .collect(Collectors.toList());
    }
```

## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
이전 [pr](https://github.com/GDG-PKNU-Fondant/fondant-backend/pull/87)을 병합하여 작업했기 때문에 지금 pr base 브랜치가 #78입니다! 이전 pr 먼저 머지 후 현재 브랜치를 다시 develop 기준으로 리베이스 해야 하니 #78 먼저 머지 부탁드립니다!!