### PR TITLE
[Fix] 마켓 테스트에서 서브 카테고리 에러 수정

### DIFF
--- a/src/main/java/com/fondant/market/application/MarketService.java
+++ b/src/main/java/com/fondant/market/application/MarketService.java
@@ -34,6 +34,7 @@ public class MarketService {
 
         Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
         Page<MarketEntity> markets = marketRepository.findMarketsByCategory(categoryId, effectivePageable);
+        // Page<MarketEntity> markets = marketRepository.findMarketsByCategoryWithSubCategories(categoryId, effectivePageable);
 
         if (markets.isEmpty()) {
             throw new ApiException(MarketError.NO_MARKETS_FOUND);
@@ -69,6 +70,7 @@ public class MarketService {
         Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
         Page<MarketEntity> markets = marketRepository.findTop10MarketsByPopularity(effectivePageable);
 
+
         if (markets == null || markets.isEmpty()) {
             throw new ApiException(MarketError.NO_MARKETS_FOUND);
         }
@@ -83,6 +85,7 @@ public class MarketService {
     public MarketsResponse getRandomTop5MarketsByCategoryId(Long categoryId, Pageable pageable) {
         Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
         Page<MarketEntity> markets = marketRepository.findRandomTop5MarketsByCategory(categoryId, effectivePageable);
+        // Page<MarketEntity> markets = marketRepository.findRandomTop5MarketsByCategoryWithSubCategories(categoryId, effectivePageable);
 
         if (markets == null || markets.isEmpty()) {
             throw new ApiException(MarketError.NO_MARKETS_FOUND);
@@ -102,6 +105,7 @@ public class MarketService {
 
         Pageable effectivePageable = (pageable == null) ? pageConfig.defaultPageable() : pageable;
         Page<MarketEntity> markets = marketRepository.findTop30MarketsByCategory(categoryId, effectivePageable);
+        // Page<MarketEntity> markets = marketRepository.findTop30MarketsByCategoryWithSubCategories(categoryId, effectivePageable);
 
         return MarketsResponse.builder()
                 .pageInfo(PageInfo.of(markets.getNumber(), markets.getTotalPages()))

--- a/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/fondant/market/domain/repository/MarketRepositoryImpl.java
@@ -65,6 +65,46 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         return new PageImpl<>(content, pageable, total);
     }
 
+    /*
+    // 부모/자식 카테고리 포함 통합 조회
+    public Page<MarketEntity> findMarketsByCategoryWithSubCategories(Long categoryId, Pageable pageable) {
+        QMarketEntity market = QMarketEntity.marketEntity;
+        QMarketCategoryEntity marketCategory = QMarketCategoryEntity.marketCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        // 모든 자식 카테고리 id를 포함한 id 리스트 조회
+        List<Long> categoryIds = queryFactory
+                .select(category.id)
+                .from(category)
+                .where(
+                    category.id.eq(categoryId)
+                        .or(category.parent.id.eq(categoryId))
+                )
+                .fetch();
+
+        // 조회 쿼리 (IN 조건으로 부모/자식 모두 포함)
+        List<MarketEntity> content = queryFactory
+                .selectDistinct(market)
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(category.id.in(categoryIds))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(market.count())
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(category.id.in(categoryIds))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+*/
+
     @Override
     public Page<MarketEntity> findTop10MarketsByPopularity(Pageable pageable) {
         QMarketEntity market = QMarketEntity.marketEntity;
@@ -113,6 +153,50 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
 
         return new PageImpl<>(markets, pageable, markets.size());
     }
+
+    /*
+    // 부모/자식 카테고리 포함 통합 랜덤 Top5 조회
+    public Page<MarketEntity> findRandomTop5MarketsByCategoryWithSubCategories(Long categoryId, Pageable pageable) {
+        QMarketEntity market = QMarketEntity.marketEntity;
+        QMarketCategoryEntity marketCategory = QMarketCategoryEntity.marketCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        NumberExpression<Double> popularityScore = calculatePopularityScore(market);
+
+        // 모든 자식 카테고리 id를 포함한 id 리스트 조회
+        List<Long> categoryIds = queryFactory
+                .select(category.id)
+                .from(category)
+                .where(
+                    category.id.eq(categoryId)
+                        .or(category.parent.id.eq(categoryId))
+                )
+                .fetch();
+
+        // 인기순으로 30개까지 조회
+        JPQLQuery<Long> subQuery = JPAExpressions
+                .select(market.id)
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(
+                    category.id.in(categoryIds)
+                        .and(market.createAt.isNotNull())
+                )
+                .orderBy(popularityScore.desc())
+                .limit(30);
+
+        // 30개 중 랜덤 5개 추출
+        List<MarketEntity> markets = queryFactory
+                .selectFrom(market)
+                .where(market.id.in(subQuery))
+                .orderBy(Expressions.numberTemplate(Double.class, "random()").asc())
+                .limit(5)
+                .fetch();
+
+        return new PageImpl<>(markets, pageable, markets.size());
+    }
+*/
 
     @Override
     public Page<MarketEntity> findTop30MarketsByCategory(Long categoryId, Pageable pageable) {
@@ -169,6 +253,63 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
 
         return new PageImpl<>(pageContent, pageable, total);
     }
+
+    /*
+    // 부모/자식 카테고리 포함 통합 top30 조회
+    public Page<MarketEntity> findTop30MarketsByCategoryWithSubCategories(Long categoryId, Pageable pageable) {
+        QMarketEntity market = QMarketEntity.marketEntity;
+        QMarketCategoryEntity marketCategory = QMarketCategoryEntity.marketCategoryEntity;
+        QCategoryEntity category = QCategoryEntity.categoryEntity;
+
+        NumberExpression<Double> popularityScore = calculatePopularityScore(market);
+
+        // 모든 자식 카테고리 id를 포함한 id 리스트 조회
+        List<Long> categoryIds = queryFactory
+                .select(category.id)
+                .from(category)
+                .where(
+                    category.id.eq(categoryId)
+                        .or(category.parent.id.eq(categoryId))
+                )
+                .fetch();
+
+        // 조회 쿼리 (IN 조건으로 부모/자식 모두 포함)
+        List<MarketEntity> top30Markets = queryFactory
+                .select(market)
+                .from(marketCategory)
+                .join(marketCategory.market, market)
+                .join(marketCategory.category, category)
+                .where(
+                    category.id.in(categoryIds)
+                        .and(market.createAt.isNotNull())
+                )
+                .groupBy(
+                    market.id,
+                    market.createAt,
+                    market.description,
+                    market.name,
+                    market.thumbnail,
+                    market.totalReviews,
+                    market.totalSales
+                )
+                .orderBy(popularityScore.desc())
+                .limit(30)
+                .fetch();
+
+        if (top30Markets.isEmpty()) {
+            throw new ApiException(MarketError.NO_MARKETS_FOUND);
+        }
+
+        long total = Math.min(top30Markets.size(), 30);
+
+        int offset = (int) pageable.getOffset();
+        int pageSize = pageable.getPageSize();
+        int end = Math.min(offset + pageSize, top30Markets.size());
+        List<MarketEntity> pageContent = top30Markets.subList(offset, end);
+
+        return new PageImpl<>(pageContent, pageable, total);
+    }
+*/
 
     @Override
     public boolean isMarketInTop10ByCategory(Long marketId) {

--- a/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/MarketRestDocsTest.java
@@ -58,7 +58,6 @@ public class MarketRestDocsTest {
     @Autowired
     private MarketLikeTestRepository marketLikeRepository;
 
-
     private CategoryEntity categoryCookie;
     private CategoryEntity categoryBread;
     private CategoryEntity categoryBakedGoods;
@@ -68,20 +67,23 @@ public class MarketRestDocsTest {
     @BeforeEach
     void setUp() {
         marketCategoryRepository.deleteAll();
-        categoryRepository.deleteAll();
+        marketHashtagRepository.deleteAll();
+        marketLikeRepository.deleteAll();
         marketRepository.deleteAll();
+        categoryRepository.deleteAll();
+        userRepository.deleteAll();
 
-        CategoryEntity categoryCookie = CategoryEntity.builder()
+        categoryCookie = CategoryEntity.builder()
                 .name("쿠키")
                 .iconUrl("domain/icon-url/cookie")
                 .build();
 
-        CategoryEntity categoryBread = CategoryEntity.builder()
+        categoryBread = CategoryEntity.builder()
                 .name("빵")
                 .iconUrl("domain/icon-url/bread")
                 .build();
 
-        CategoryEntity categoryBakedGoods = CategoryEntity.builder()
+        categoryBakedGoods = CategoryEntity.builder()
                 .name("구움과자")
                 .iconUrl("domain/icon-url/baked")
                 .build();
@@ -95,9 +97,10 @@ public class MarketRestDocsTest {
         categoryBakedGoods.addChild(CategoryEntity.builder().name("마들렌").build());
         categoryBakedGoods.addChild(CategoryEntity.builder().name("휘낭시에").build());
 
-        categoryRepository.save(categoryCookie);
-        categoryRepository.save(categoryBread);
-        categoryRepository.save(categoryBakedGoods);
+        categoryCookie = categoryRepository.save(categoryCookie);
+        categoryBread = categoryRepository.save(categoryBread);
+        categoryBakedGoods = categoryRepository.save(categoryBakedGoods);
+
 
         int marketCount = 1;
         for (CategoryEntity category : List.of(categoryCookie, categoryBread, categoryBakedGoods)) {
@@ -133,7 +136,9 @@ public class MarketRestDocsTest {
     @Test
     @WithMockCustomUser
     void getMarketsByCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/categories/{categoryId}", categoryBread.getId())
+        CategoryEntity subCategory = categoryBread.getChildren().get(0);
+
+        mockMvc.perform(get(BASE_URL + "/categories/{categoryId}", subCategory.getId())
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -235,7 +240,9 @@ public class MarketRestDocsTest {
     @Test
     @WithMockCustomUser
     void getTop30MarketsByCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/{categoryId}/top30", categoryCookie.getId())
+        CategoryEntity subCategory = categoryCookie.getChildren().get(0);
+
+        mockMvc.perform(get(BASE_URL + "/{categoryId}/top30", subCategory.getId())
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -264,10 +271,13 @@ public class MarketRestDocsTest {
                         })));
     }
 
+
     @Test
     @WithMockCustomUser
     void getRandomTop5MarketsByCategory() throws Exception {
-        mockMvc.perform(get(BASE_URL + "/{categoryId}/top5", categoryCookie.getId())
+        CategoryEntity subCategory = categoryCookie.getChildren().get(0);
+
+        mockMvc.perform(get(BASE_URL + "/{categoryId}/top5", subCategory.getId())
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- closes #97 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
develop 브랜치에서 마켓 테스트가 터진다는 이슈가 있어서 해결했습니다.
부모-자식 카테고리 구조 반영을 안 해서 에러가 났었던 것 같습니다!
기존 메인 카테고리 기준 조회에서 서브 카테고리 기준 조회로 변경했습니다.
<img width="628" alt="image" src="https://github.com/user-attachments/assets/bf861970-e216-4bbe-9645-321da5f2c6c8" />


## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
테스트는 서브 카테고리 기준 조회로 변경했는데 회의 후 필요하다면 인기순 조회 시 상위/하위 카테고리 통합 조회 가능하도록 주석으로 쿼리 작성했습니다. 통합 조회면 서비스는 다시 부모 카테고리 기준으로 변경하면 될 것 같습니다