### PR TITLE
[Feat] 장바구니 기능 구현

### DIFF
--- a/src/docs/CartRestDocs.adoc
+++ b/src/docs/CartRestDocs.adoc
@@ -21,3 +21,39 @@ include::{snippets}/cart/get-cart-items/http-response.adoc[]
 ==== response body
 
 include::{snippets}/cart/get-cart-items/response-fields.adoc[]
+
+=== 2. 장바구니 항목 추가
+
+==== HTTP request
+
+include::{snippets}/cart/add-cart-item/http-request.adoc[]
+
+==== request body
+
+include::{snippets}/cart/add-cart-item/request-fields.adoc[]
+
+==== HTTP response
+
+include::{snippets}/cart/add-cart-item/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/cart/add-cart-item/response-fields.adoc[]
+
+=== 3. 장바구니 항목 수량 수정
+
+==== HTTP request
+
+include::{snippets}/cart/update-cart-item/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/cart/update-cart-item/http-response.adoc[]
+
+==== response body
+
+include::{snippets}/cart/update-cart-item/response-fields.adoc[]
+
+=== 4. 장바구니 항목 해당 마켓 상품 전체 삭제
+
+=== 5. 장바구니 항목 선택한 상품 삭제

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -3,11 +3,23 @@ package com.fondant.cart.application;
 import com.fondant.cart.application.dto.CartMarketInfo;
 import com.fondant.cart.application.dto.CartOptionInfo;
 import com.fondant.cart.application.dto.CartProductInfo;
+import com.fondant.cart.application.dto.*;
+import com.fondant.cart.domain.entity.CartEntity;
 import com.fondant.cart.domain.entity.CartItemEntity;
+import com.fondant.cart.domain.entity.CartItemOptionEntity;
+import com.fondant.cart.domain.entity.CartMarketEntity;
 import com.fondant.cart.domain.repository.CartRepository;
 import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.PageInfo;
 import com.fondant.cart.presentation.dto.response.CartResponse;
+import com.fondant.market.domain.entity.MarketEntity;
+import com.fondant.product.domain.entity.OptionEntity;
+import com.fondant.product.domain.entity.ProductEntity;
+import com.fondant.product.domain.repository.OptionRepository;
+import com.fondant.product.domain.repository.ProductRepository;
+import com.fondant.user.application.UserService;
+import com.fondant.user.domain.entity.UserEntity;
+import com.fondant.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +34,9 @@ import java.util.stream.Collectors;
 public class CartService {
 
     private final CartRepository cartRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+    private final OptionRepository optionRepository;
     private final PageConfig pageConfig;
 
     @Transactional(readOnly = true)
@@ -82,5 +97,54 @@ public class CartService {
                             .build();
                 })
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void addCartItem(Long userId, CartInfo request) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+
+        ProductEntity product = productRepository.findById(request.productId())
+                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+
+        MarketEntity market = product.getMarket();
+
+        CartEntity cart = cartRepository.findByUserId(userId)
+                .orElseGet(() -> cartRepository.save(CartEntity.builder().user(user).build()));
+
+        CartMarketEntity cartMarket = cart.getCartMarkets().stream()
+                .filter(cm -> cm.getMarket().equals(market))
+                .findFirst()
+                .orElseGet(() -> {
+                    CartMarketEntity newMarket = CartMarketEntity.builder()
+                            .cart(cart)
+                            .market(market)
+                            .build();
+                    cart.getCartMarkets().add(newMarket);
+                    return newMarket;
+                });
+
+        CartItemEntity cartItem = CartItemEntity.builder()
+                .cartMarket(cartMarket)
+                .product(product)
+                .quantity(request.quantity())
+                .arrivalDate(null)
+                .build();
+
+        if (request.options() != null && !request.options().isEmpty()) {
+            for (CartInfo.OptionInfo optReq : request.options()) {
+                OptionEntity option = optionRepository.findById(optReq.optionId())
+                        .orElseThrow(() -> new IllegalArgumentException("옵션이 존재하지 않습니다."));
+                CartItemOptionEntity optionEntity = CartItemOptionEntity.builder()
+                        .cartItem(cartItem)
+                        .option(option)
+                        .quantity(optReq.quantity())
+                        .build();
+                cartItem.addCartItemOption(optionEntity);
+            }
+        }
+
+        cartMarket.getCartItems().add(cartItem);
+        cartRepository.save(cart);
     }
 }

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -6,6 +6,7 @@ import com.fondant.cart.domain.entity.CartItemEntity;
 import com.fondant.cart.domain.entity.CartItemOptionEntity;
 import com.fondant.cart.domain.entity.CartMarketEntity;
 import com.fondant.cart.domain.repository.CartRepository;
+import com.fondant.cart.presentation.dto.response.CartItemResponse;
 import com.fondant.global.config.PageConfig;
 import com.fondant.global.dto.PageInfo;
 import com.fondant.cart.presentation.dto.response.CartResponse;
@@ -78,7 +79,7 @@ public class CartService {
                             .map(opt -> CartOptionInfo.builder()
                                     .optionId(opt.getOption().getId())
                                     .optionName(opt.getOption().getName())
-                                    .additionalPrice((double) opt.getOption().getPrice())
+                                    .additionalPrice(opt.getOption().getPrice())
                                     .quantity(opt.getQuantity())
                                     .build())
                             .collect(Collectors.toList());
@@ -97,7 +98,7 @@ public class CartService {
     }
 
     @Transactional
-    public void addCartItem(Long userId, CartInfo request) {
+    public CartItemResponse addCartItem(Long userId, CartInfo request) {
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
 
@@ -143,10 +144,22 @@ public class CartService {
 
         cartMarket.getCartItems().add(cartItem);
         cartRepository.save(cart);
+
+        return new CartItemResponse(
+                product.getId(),
+                product.getName(),
+                request.quantity(),
+                cartItem.getCartItemOptions().stream()
+                        .map(opt -> new CartItemResponse.OptionResponse(
+                                opt.getOption().getId(),
+                                opt.getOption().getName(),
+                                opt.getQuantity()))
+                        .toList()
+        );
     }
 
     @Transactional
-    public void updateCartItem(Long userId, Long cartItemId, CartUpdateInfo request) {
+    public CartItemResponse updateCartItem(Long userId, Long cartItemId, CartUpdateInfo request) {
         CartItemEntity cartItem = cartItemRepository.findByIdAndUserId(cartItemId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("장바구니 상품이 존재하지 않습니다."));
 
@@ -160,6 +173,20 @@ public class CartService {
                         .ifPresent(option -> option.changeQuantity(optionRequest.quantity()));
             }
         }
+
+        ProductEntity product = cartItem.getProduct();
+
+        return new CartItemResponse(
+                product.getId(),
+                product.getName(),
+                cartItem.getQuantity(),
+                cartItem.getCartItemOptions().stream()
+                        .map(opt -> new CartItemResponse.OptionResponse(
+                                opt.getOption().getId(),
+                                opt.getOption().getName(),
+                                opt.getQuantity()))
+                        .toList()
+        );
     }
 
     @Transactional
@@ -167,8 +194,8 @@ public class CartService {
         CartItemEntity cartItem = cartItemRepository.findByIdAndUserId(cartItemId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("장바구니 항목이 존재하지 않습니다."));
 
-        cartItem.getCartMarket().getCartItems().remove(cartItem); // 연관관계 끊기
-        cartItemRepository.delete(cartItem); // 실제 삭제
+        cartItem.getCartMarket().getCartItems().remove(cartItem);
+        cartItemRepository.delete(cartItem);
     }
 
 }

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -1,8 +1,5 @@
 package com.fondant.cart.application;
 
-import com.fondant.cart.application.dto.CartMarketInfo;
-import com.fondant.cart.application.dto.CartOptionInfo;
-import com.fondant.cart.application.dto.CartProductInfo;
 import com.fondant.cart.application.dto.*;
 import com.fondant.cart.domain.entity.CartEntity;
 import com.fondant.cart.domain.entity.CartItemEntity;
@@ -146,5 +143,22 @@ public class CartService {
 
         cartMarket.getCartItems().add(cartItem);
         cartRepository.save(cart);
+    }
+
+    @Transactional
+    public void updateCartItem(Long userId, Long cartItemId, CartUpdateInfo request) {
+        CartItemEntity cartItem = cartRepository.findCartItemByIdAndUserId(cartItemId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니 상품이 존재하지 않습니다."));
+
+        cartItem.changeQuantity(request.quantity());
+
+        if (request.options() != null && !request.options().isEmpty()) {
+            for (CartUpdateInfo.OptionUpdateInfo optionRequest : request.options()) {
+                cartItem.getCartItemOptions().stream()
+                        .filter(option -> option.getOption().getId().equals(optionRequest.optionId()))
+                        .findFirst()
+                        .ifPresent(option -> option.changeQuantity(optionRequest.quantity()));
+            }
+        }
     }
 }

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -29,12 +29,11 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class CartService {
-
     private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
     private final OptionRepository optionRepository;
-    private final CartItemRepository cartItemRepository;
     private final PageConfig pageConfig;
 
     @Transactional(readOnly = true)
@@ -56,7 +55,7 @@ public class CartService {
                 .map(entry -> {
                     Long marketId = entry.getKey();
                     List<CartItemEntity> items = entry.getValue();
-                    var market = items.get(0).getCartMarket().getMarket();
+                    MarketEntity market = items.get(0).getCartMarket().getMarket();
 
                     List<CartProductInfo> products = toCartProductInfoList(items);
 
@@ -148,7 +147,7 @@ public class CartService {
 
     @Transactional
     public void updateCartItem(Long userId, Long cartItemId, CartUpdateInfo request) {
-        CartItemEntity cartItem = cartRepository.findCartItemByIdAndUserId(cartItemId, userId)
+        CartItemEntity cartItem = cartItemRepository.findByIdAndUserId(cartItemId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("장바구니 상품이 존재하지 않습니다."));
 
         cartItem.changeQuantity(request.quantity());
@@ -165,12 +164,11 @@ public class CartService {
 
     @Transactional
     public void deleteCartItem(Long userId, Long cartItemId) {
-        CartItemEntity cartItem = cartRepository.findCartItemByIdAndUserId(cartItemId, userId)
+        CartItemEntity cartItem = cartItemRepository.findByIdAndUserId(cartItemId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("장바구니 항목이 존재하지 않습니다."));
 
-        cartItem.getCartMarket().getCartItems().remove(cartItem);
-
-        cartItemRepository.delete(cartItem);
+        cartItem.getCartMarket().getCartItems().remove(cartItem); // 연관관계 끊기
+        cartItemRepository.delete(cartItem); // 실제 삭제
     }
 
     @Transactional

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -171,16 +171,4 @@ public class CartService {
         cartItemRepository.delete(cartItem); // 실제 삭제
     }
 
-    @Transactional
-    public void deleteCartItemsByMarket(Long userId, Long marketId) {
-        CartEntity cart = cartRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("장바구니가 존재하지 않습니다."));
-
-        CartMarketEntity targetMarket = cart.getCartMarkets().stream()
-                .filter(cm -> cm.getMarket().getId().equals(marketId))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("해당 마켓의 장바구니 항목이 존재하지 않습니다."));
-
-        cart.getCartMarkets().remove(targetMarket);
-    }
 }

--- a/src/main/java/com/fondant/cart/application/CartService.java
+++ b/src/main/java/com/fondant/cart/application/CartService.java
@@ -14,7 +14,7 @@ import com.fondant.product.domain.entity.OptionEntity;
 import com.fondant.product.domain.entity.ProductEntity;
 import com.fondant.product.domain.repository.OptionRepository;
 import com.fondant.product.domain.repository.ProductRepository;
-import com.fondant.user.application.UserService;
+import com.fondant.cart.domain.repository.CartItemRepository;
 import com.fondant.user.domain.entity.UserEntity;
 import com.fondant.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +34,7 @@ public class CartService {
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
     private final OptionRepository optionRepository;
+    private final CartItemRepository cartItemRepository;
     private final PageConfig pageConfig;
 
     @Transactional(readOnly = true)
@@ -160,5 +161,28 @@ public class CartService {
                         .ifPresent(option -> option.changeQuantity(optionRequest.quantity()));
             }
         }
+    }
+
+    @Transactional
+    public void deleteCartItem(Long userId, Long cartItemId) {
+        CartItemEntity cartItem = cartRepository.findCartItemByIdAndUserId(cartItemId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니 항목이 존재하지 않습니다."));
+
+        cartItem.getCartMarket().getCartItems().remove(cartItem);
+
+        cartItemRepository.delete(cartItem);
+    }
+
+    @Transactional
+    public void deleteCartItemsByMarket(Long userId, Long marketId) {
+        CartEntity cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니가 존재하지 않습니다."));
+
+        CartMarketEntity targetMarket = cart.getCartMarkets().stream()
+                .filter(cm -> cm.getMarket().getId().equals(marketId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 마켓의 장바구니 항목이 존재하지 않습니다."));
+
+        cart.getCartMarkets().remove(targetMarket);
     }
 }

--- a/src/main/java/com/fondant/cart/application/dto/CartInfo.java
+++ b/src/main/java/com/fondant/cart/application/dto/CartInfo.java
@@ -1,0 +1,18 @@
+package com.fondant.cart.application.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CartInfo(
+        Long productId,
+        int quantity,
+        List<OptionInfo> options
+) {
+    @Builder
+    public record OptionInfo(
+            Long optionId,
+            int quantity
+    ) {}
+}

--- a/src/main/java/com/fondant/cart/application/dto/CartUpdateInfo.java
+++ b/src/main/java/com/fondant/cart/application/dto/CartUpdateInfo.java
@@ -1,0 +1,17 @@
+package com.fondant.cart.application.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CartUpdateInfo(
+        int quantity,
+        List<OptionUpdateInfo> options
+) {
+    @Builder
+    public record OptionUpdateInfo(
+            Long optionId,
+            int quantity
+    ) {}
+}

--- a/src/main/java/com/fondant/cart/domain/entity/CartEntity.java
+++ b/src/main/java/com/fondant/cart/domain/entity/CartEntity.java
@@ -4,10 +4,12 @@ import com.fondant.user.domain.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CartEntity {

--- a/src/main/java/com/fondant/cart/domain/entity/CartEntity.java
+++ b/src/main/java/com/fondant/cart/domain/entity/CartEntity.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -23,7 +24,7 @@ public class CartEntity {
     private UserEntity user;
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<CartMarketEntity> cartMarkets;
+    private List<CartMarketEntity> cartMarkets = new ArrayList<>();
 
     @Builder
     public CartEntity(UserEntity user) {

--- a/src/main/java/com/fondant/cart/domain/entity/CartItemEntity.java
+++ b/src/main/java/com/fondant/cart/domain/entity/CartItemEntity.java
@@ -52,4 +52,8 @@ public class CartItemEntity {
         this.cartItemOptions.add(option);
         option.setCartItem(this);
     }
+
+    public void changeQuantity(int quantity) {
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/fondant/cart/domain/entity/CartItemOptionEntity.java
+++ b/src/main/java/com/fondant/cart/domain/entity/CartItemOptionEntity.java
@@ -36,4 +36,8 @@ public class CartItemOptionEntity {
     public void setCartItem(CartItemEntity cartItem) {
         this.cartItem = cartItem;
     }
+
+    public void changeQuantity(int quantity) {
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/fondant/cart/domain/repository/CartItemRepository.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartItemRepository.java
@@ -1,0 +1,7 @@
+package com.fondant.cart.domain.repository;
+
+import com.fondant.cart.domain.entity.CartItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItemEntity, Long> {
+}

--- a/src/main/java/com/fondant/cart/domain/repository/CartItemRepositoryCustom.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartItemRepositoryCustom.java
@@ -1,10 +1,9 @@
 package com.fondant.cart.domain.repository;
 
 import com.fondant.cart.domain.entity.CartItemEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface CartItemRepository extends JpaRepository<CartItemEntity, Long>, CartItemRepositoryCustom {
+public interface CartItemRepositoryCustom {
     Optional<CartItemEntity> findByIdAndUserId(Long cartItemId, Long userId);
 }

--- a/src/main/java/com/fondant/cart/domain/repository/CartItemRepositoryImpl.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartItemRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.fondant.cart.domain.repository;
+
+import com.fondant.cart.domain.entity.CartItemEntity;
+import com.fondant.cart.domain.entity.QCartEntity;
+import com.fondant.cart.domain.entity.QCartItemEntity;
+import com.fondant.cart.domain.entity.QCartMarketEntity;
+import com.fondant.user.domain.entity.QUserEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CartItemRepositoryImpl implements CartItemRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<CartItemEntity> findByIdAndUserId(Long cartItemId, Long userId) {
+        QCartItemEntity cartItem = QCartItemEntity.cartItemEntity;
+        QCartMarketEntity cartMarket = QCartMarketEntity.cartMarketEntity;
+        QCartEntity cart = QCartEntity.cartEntity;
+        QUserEntity user = QUserEntity.userEntity;
+
+        CartItemEntity result = queryFactory
+                .select(cartItem)
+                .from(cartItem)
+                .join(cartItem.cartMarket, cartMarket).fetchJoin()
+                .join(cartMarket.cart, cart).fetchJoin()
+                .join(cart.user, user)
+                .where(cartItem.id.eq(cartItemId), user.id.eq(userId))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepository.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepository.java
@@ -3,6 +3,9 @@ package com.fondant.cart.domain.repository;
 import com.fondant.cart.domain.entity.CartEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CartRepository extends JpaRepository<CartEntity, Long>, CartRepositoryCustom {
+   Optional<CartEntity> findByUserId(Long userId);
 }
 

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepository.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepository.java
@@ -1,13 +1,10 @@
 package com.fondant.cart.domain.repository;
 
 import com.fondant.cart.domain.entity.CartEntity;
-import com.fondant.cart.domain.entity.CartItemEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<CartEntity, Long>, CartRepositoryCustom {
    Optional<CartEntity> findByUserId(Long userId);
-   Optional<CartItemEntity> findCartItemByIdAndUserId(Long cartItemId, Long userId);
 }
-

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepository.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepository.java
@@ -1,11 +1,13 @@
 package com.fondant.cart.domain.repository;
 
 import com.fondant.cart.domain.entity.CartEntity;
+import com.fondant.cart.domain.entity.CartItemEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<CartEntity, Long>, CartRepositoryCustom {
    Optional<CartEntity> findByUserId(Long userId);
+   Optional<CartItemEntity> findCartItemByIdAndUserId(Long cartItemId, Long userId);
 }
 

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepositoryCustom.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface CartRepositoryCustom {
     Page<CartItemEntity> findCartItemsByUser(Long userId, Pageable pageable);
 
     Optional<CartEntity> findByUserId(Long userId);
+
+    Optional<CartItemEntity> findCartItemByIdAndUserId(Long cartItemId, Long userId);
 }

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepositoryCustom.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepositoryCustom.java
@@ -1,8 +1,13 @@
 package com.fondant.cart.domain.repository;
+import com.fondant.cart.domain.entity.CartEntity;
 import com.fondant.cart.domain.entity.CartItemEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface CartRepositoryCustom {
     Page<CartItemEntity> findCartItemsByUser(Long userId, Pageable pageable);
+
+    Optional<CartEntity> findByUserId(Long userId);
 }

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepositoryCustom.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepositoryCustom.java
@@ -10,6 +10,4 @@ public interface CartRepositoryCustom {
     Page<CartItemEntity> findCartItemsByUser(Long userId, Pageable pageable);
 
     Optional<CartEntity> findByUserId(Long userId);
-
-    Optional<CartItemEntity> findCartItemByIdAndUserId(Long cartItemId, Long userId);
 }

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepositoryImpl.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepositoryImpl.java
@@ -74,23 +74,4 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
 
         return Optional.ofNullable(cartEntity);
     }
-
-    @Override
-    public Optional<CartItemEntity> findCartItemByIdAndUserId(Long cartItemId, Long userId) {
-        QCartItemEntity cartItem = QCartItemEntity.cartItemEntity;
-        QCartMarketEntity cartMarket = QCartMarketEntity.cartMarketEntity;
-        QCartEntity cart = QCartEntity.cartEntity;
-        QUserEntity user = QUserEntity.userEntity;
-
-        CartItemEntity result = queryFactory
-                .select(cartItem)
-                .from(cartItem)
-                .join(cartItem.cartMarket, cartMarket).fetchJoin()
-                .join(cartMarket.cart, cart).fetchJoin()
-                .join(cart.user, user)
-                .where(cartItem.id.eq(cartItemId), user.id.eq(userId))
-                .fetchOne();
-
-        return Optional.ofNullable(result);
-    }
 }

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepositoryImpl.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepositoryImpl.java
@@ -75,4 +75,22 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
         return Optional.ofNullable(cartEntity);
     }
 
+    @Override
+    public Optional<CartItemEntity> findCartItemByIdAndUserId(Long cartItemId, Long userId) {
+        QCartItemEntity cartItem = QCartItemEntity.cartItemEntity;
+        QCartMarketEntity cartMarket = QCartMarketEntity.cartMarketEntity;
+        QCartEntity cart = QCartEntity.cartEntity;
+        QUserEntity user = QUserEntity.userEntity;
+
+        CartItemEntity result = queryFactory
+                .select(cartItem)
+                .from(cartItem)
+                .join(cartItem.cartMarket, cartMarket).fetchJoin()
+                .join(cartMarket.cart, cart).fetchJoin()
+                .join(cart.user, user)
+                .where(cartItem.id.eq(cartItemId), user.id.eq(userId))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
 }

--- a/src/main/java/com/fondant/cart/domain/repository/CartRepositoryImpl.java
+++ b/src/main/java/com/fondant/cart/domain/repository/CartRepositoryImpl.java
@@ -1,10 +1,6 @@
 package com.fondant.cart.domain.repository;
 
-import com.fondant.cart.domain.entity.CartItemEntity;
-import com.fondant.cart.domain.entity.QCartEntity;
-import com.fondant.cart.domain.entity.QCartItemEntity;
-import com.fondant.cart.domain.entity.QCartItemOptionEntity;
-import com.fondant.cart.domain.entity.QCartMarketEntity;
+import com.fondant.cart.domain.entity.*;
 import com.fondant.market.domain.entity.QMarketEntity;
 import com.fondant.product.domain.entity.QOptionEntity;
 import com.fondant.product.domain.entity.QProductEntity;
@@ -17,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CartRepositoryImpl implements CartRepositoryCustom {
@@ -62,4 +59,20 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
+
+    @Override
+    public Optional<CartEntity> findByUserId(Long userId) {
+        QCartEntity cart = QCartEntity.cartEntity;
+        QUserEntity user = QUserEntity.userEntity;
+
+        CartEntity cartEntity = queryFactory
+                .selectFrom(cart)
+                .join(cart.user, user).fetchJoin()
+                .leftJoin(cart.cartMarkets).fetchJoin()
+                .where(user.id.eq(userId))
+                .fetchOne();
+
+        return Optional.ofNullable(cartEntity);
+    }
+
 }

--- a/src/main/java/com/fondant/cart/presentation/CartController.java
+++ b/src/main/java/com/fondant/cart/presentation/CartController.java
@@ -1,6 +1,8 @@
 package com.fondant.cart.presentation;
 
 import com.fondant.cart.application.CartService;
+import com.fondant.cart.application.dto.CartInfo;
+import com.fondant.cart.application.dto.CartUpdateInfo;
 import com.fondant.cart.presentation.dto.response.CartResponse;
 import com.fondant.global.annotation.CurrentUser;
 import com.fondant.global.dto.ResponseDto;
@@ -29,4 +31,14 @@ public class CartController {
                 ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response)
         );
     }
+
+    @PostMapping("/add")
+    public ResponseEntity<ResponseDto<Void>> addCartItem(
+            @CurrentUser CustomUserDetails user,
+            @RequestBody CartInfo request
+    ) {
+        cartService.addCartItem(user.getUserId(), request);
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
+    }
+
 }

--- a/src/main/java/com/fondant/cart/presentation/CartController.java
+++ b/src/main/java/com/fondant/cart/presentation/CartController.java
@@ -41,4 +41,13 @@ public class CartController {
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
     }
 
+    @PatchMapping("/items/{cartItemId}")
+    public ResponseEntity<ResponseDto<Void>> updateCartItem(
+            @CurrentUser CustomUserDetails user,
+            @PathVariable Long cartItemId,
+            @RequestBody CartUpdateInfo request
+    ) {
+        cartService.updateCartItem(user.getUserId(), cartItemId, request);
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
+    }
 }

--- a/src/main/java/com/fondant/cart/presentation/CartController.java
+++ b/src/main/java/com/fondant/cart/presentation/CartController.java
@@ -3,6 +3,7 @@ package com.fondant.cart.presentation;
 import com.fondant.cart.application.CartService;
 import com.fondant.cart.application.dto.CartInfo;
 import com.fondant.cart.application.dto.CartUpdateInfo;
+import com.fondant.cart.presentation.dto.response.CartItemResponse;
 import com.fondant.cart.presentation.dto.response.CartResponse;
 import com.fondant.global.annotation.CurrentUser;
 import com.fondant.global.dto.ResponseDto;
@@ -33,22 +34,22 @@ public class CartController {
     }
 
     @PostMapping("/add")
-    public ResponseEntity<ResponseDto<Void>> addCartItem(
+    public ResponseEntity<ResponseDto<CartItemResponse>> addCartItem(
             @CurrentUser CustomUserDetails user,
             @RequestBody CartInfo request
     ) {
-        cartService.addCartItem(user.getUserId(), request);
-        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
+        CartItemResponse response = cartService.addCartItem(user.getUserId(), request);
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response));
     }
 
     @PatchMapping("/items/{cartItemId}")
-    public ResponseEntity<ResponseDto<Void>> updateCartItem(
+    public ResponseEntity<ResponseDto<CartItemResponse>> updateCartItem(
             @CurrentUser CustomUserDetails user,
             @PathVariable Long cartItemId,
             @RequestBody CartUpdateInfo request
     ) {
-        cartService.updateCartItem(user.getUserId(), cartItemId, request);
-        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
+        CartItemResponse response = cartService.updateCartItem(user.getUserId(), cartItemId, request);
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, response));
     }
 
     @DeleteMapping("/items/{cartItemId}")

--- a/src/main/java/com/fondant/cart/presentation/CartController.java
+++ b/src/main/java/com/fondant/cart/presentation/CartController.java
@@ -50,4 +50,13 @@ public class CartController {
         cartService.updateCartItem(user.getUserId(), cartItemId, request);
         return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
     }
+
+    @DeleteMapping("/items/{cartItemId}")
+    public ResponseEntity<ResponseDto<Void>> deleteCartItem(
+            @CurrentUser CustomUserDetails user,
+            @PathVariable Long cartItemId
+    ) {
+        cartService.deleteCartItem(user.getUserId(), cartItemId);
+        return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS));
+    }
 }

--- a/src/main/java/com/fondant/cart/presentation/dto/response/CartItemResponse.java
+++ b/src/main/java/com/fondant/cart/presentation/dto/response/CartItemResponse.java
@@ -1,0 +1,16 @@
+package com.fondant.cart.presentation.dto.response;
+
+import java.util.List;
+
+public record CartItemResponse(
+        Long productId,
+        String productName,
+        int quantity,
+        List<OptionResponse> options
+) {
+    public record OptionResponse(
+            Long optionId,
+            String optionName,
+            int quantity
+    ) {}
+}

--- a/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
@@ -1,7 +1,7 @@
 package com.fondant.restdocs;
 
-import com.fondant.cart.application.CartService;
 import com.fondant.cart.domain.entity.*;
+import com.fondant.global.annotation.WithMockCustomUser;
 import com.fondant.infra.jwt.application.JWTUtil;
 import com.fondant.market.domain.entity.MarketEntity;
 import com.fondant.product.domain.entity.OptionEntity;
@@ -10,31 +10,31 @@ import com.fondant.product.domain.repository.OptionRepository;
 import com.fondant.product.domain.repository.ProductRepository;
 import com.fondant.test.repository.*;
 import com.fondant.user.domain.entity.*;
+import com.fondant.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
 import java.time.LocalDate;
 
-import static java.sql.JDBCType.ARRAY;
-import static javax.management.openmbean.SimpleType.STRING;
-import static javax.swing.text.html.parser.DTDConstants.NUMBER;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -44,39 +44,41 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class CartRestDocsTest {
 
     @Autowired private MockMvc mockMvc;
-    @Autowired private JWTUtil jwtUtil;
+    @MockitoSpyBean private JWTUtil jwtUtil;
 
     @Autowired private CartTestRepository cartTestRepository;
     @Autowired private CartMarketTestRepository cartMarketTestRepository;
     @Autowired private CartItemTestRepository cartItemTestRepository;
     @Autowired private CartItemOptionTestRepository cartItemOptionTestRepository;
-
-    @Autowired private UserTestRepository userTestRepository;
+    @Autowired private UserRepository userRepository;
     @Autowired private MarketTestRepository marketTestRepository;
     @Autowired private ProductRepository productRepository;
     @Autowired private OptionRepository optionRepository;
-    @Autowired private CartService cartService;
-    private UserEntity user;
 
-    private static final String BASE_URL = "/api/cart";
+    private UserEntity testUser;
     private String mockToken;
+    private static final String BASE_URL = "/api/cart";
 
     @BeforeEach
     void setUp() {
-        user = userTestRepository.save(
+        mockToken = "jwtToken";
+
+        testUser = userRepository.save(
                 UserEntity.builder()
-                        .snsType(SNSType.KAKAO)
-                        .name("테스트 유저")
-                        .email("test@user.com")
-                        .nickname("testuser")
-                        .birth(Date.valueOf("2000-01-01"))
+                        .snsType(SNSType.NAVER)
+                        .name("test-user")
+                        .phoneNumber("010-0000-0000")
+                        .email("test-user@example.com")
+                        .birth(Date.valueOf(LocalDate.of(2001, 1, 1)))
+                        .nickname("test-user-nickname")
+                        .profileUrl("https://example.com")
+                        .createAt(Date.valueOf(LocalDate.of(2025, 1, 1)).toLocalDate())
                         .gender(Gender.FEMALE)
                         .role(UserRole.USER)
-                        .phoneNumber("01012345678")
-                        .createAt(LocalDate.now())
-                        .profileUrl("http://profile.img")
                         .build()
         );
+
+        mockToken = jwtUtil.generateToken("access", testUser.getId(), "USER", 60 * 10 * 1000L);
 
         MarketEntity market = marketTestRepository.save(
                 MarketEntity.builder()
@@ -128,7 +130,7 @@ public class CartRestDocsTest {
 
         CartEntity cart = cartTestRepository.save(
                 CartEntity.builder()
-                        .user(user)
+                        .user(testUser)
                         .build()
         );
 
@@ -172,8 +174,6 @@ public class CartRestDocsTest {
 
         cartItemOptionTestRepository.save(itemOption1);
         cartItemOptionTestRepository.save(itemOption2);
-
-        mockToken = jwtUtil.generateToken("access", user.getId(), user.getRole().name(), 600000L);
     }
 
     public static FieldDescriptor[] commonResponseFields() {
@@ -185,10 +185,11 @@ public class CartRestDocsTest {
     }
 
     @Test
+    @WithMockCustomUser
     void getCartItems() throws Exception {
         mockMvc.perform(get(BASE_URL + "/list")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .param("page", "0")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(document("cart/get-cart-items",
@@ -216,5 +217,119 @@ public class CartRestDocsTest {
                                 fieldWithPath("markets[].products[].options[].additionalPrice").type(JsonFieldType.NUMBER).description("옵션 추가 금액"),
                                 fieldWithPath("markets[].products[].options[].quantity").type(JsonFieldType.NUMBER).description("옵션 수량")
                         })));
+    }
+
+    @Test
+    @WithMockCustomUser
+    void addCartItem() throws Exception {
+        ProductEntity productWithOption = productRepository.findAll()
+                .stream().filter(p -> p.getName().equals("딸기모찌")).findFirst().orElseThrow();
+
+        OptionEntity option1 = optionRepository.findAll()
+                .stream().filter(o -> o.getName().equals("3개 세트")).findFirst().orElseThrow();
+        OptionEntity option2 = optionRepository.findAll()
+                .stream().filter(o -> o.getName().equals("5개 세트")).findFirst().orElseThrow();
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/add")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                    {
+                      "productId": %d,
+                      "quantity": 2,
+                      "options": [
+                        {
+                          "optionId": %d,
+                          "quantity": 1
+                        },
+                        {
+                          "optionId": %d,
+                          "quantity": 2
+                        }
+                      ]
+                    }
+                    """.formatted(productWithOption.getId(), option1.getId(), option2.getId())))
+                .andExpect(status().isOk())
+                .andDo(document("cart/add-cart-item",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("productId").description("상품 ID"),
+                                fieldWithPath("quantity").description("상품 수량"),
+                                fieldWithPath("options").description("선택된 옵션 리스트").optional(),
+                                fieldWithPath("options[].optionId").description("옵션 ID"),
+                                fieldWithPath("options[].quantity").description("옵션 수량")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("content.productId").description("추가된 상품 ID"),
+                                fieldWithPath("content.productName").description("추가된 상품명"),
+                                fieldWithPath("content.quantity").description("추가된 수량"),
+                                fieldWithPath("content.options[].optionId").description("옵션 ID"),
+                                fieldWithPath("content.options[].optionName").description("옵션 이름"),
+                                fieldWithPath("content.options[].quantity").description("옵션 수량")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockCustomUser
+    void updateCartItemQuantity() throws Exception {
+        CartItemEntity cartItem = cartItemTestRepository.findAll().get(0);
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.patch("/api/cart/items/{cartItemId}", cartItem.getId())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                        {
+                          "quantity": 5
+                        }
+                    """)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("cart/update-cart-item",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("quantity").description("수정할 수량")
+                        ),
+                        pathParameters(
+                                parameterWithName("cartItemId").description("장바구니 항목 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("content.productId").type(JsonFieldType.NUMBER).description("수정된 상품 ID"),
+                                fieldWithPath("content.productName").type(JsonFieldType.STRING).description("상품 이름"),
+                                fieldWithPath("content.quantity").type(JsonFieldType.NUMBER).description("수정된 수량"),
+                                fieldWithPath("content.options").type(JsonFieldType.ARRAY).description("옵션 목록 (없으면 빈 배열)").optional(),
+                                fieldWithPath("content.options[].optionId").type(JsonFieldType.NUMBER).description("옵션 ID").optional(),
+                                fieldWithPath("content.options[].optionName").type(JsonFieldType.STRING).description("옵션 이름").optional(),
+                                fieldWithPath("content.options[].quantity").type(JsonFieldType.NUMBER).description("옵션 수량").optional()
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockCustomUser
+    void deleteCartItem() throws Exception {
+        CartItemEntity cartItem = cartItemTestRepository.findAll().get(0);
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete(BASE_URL + "/delete/{cartItemId}", cartItem.getId())
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("cart/delete-cart-item",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("cartItemId").description("장바구니 항목 ID")
+                        ),
+                        responseFields(commonResponseFields())
+                ));
     }
 }

--- a/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
+++ b/src/test/java/com/fondant/restdocs/CartRestDocsTest.java
@@ -186,7 +186,6 @@ public class CartRestDocsTest {
 
     @Test
     void getCartItems() throws Exception {
-        System.out.println(cartService.getCartItemsByUser(user.getId(), Pageable.unpaged()));
         mockMvc.perform(get(BASE_URL + "/list")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + mockToken)
                         .param("page", "0")


### PR DESCRIPTION
## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- closes #71 
- closes #100 

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
### 1️⃣ Cascade 설정 및 orphanRemoval로 연관 엔티티 자동 삭제 처리
> 장바구니 항목 삭제 시 옵션 관계도 함께 자동 삭제

- `cascade = CascadeType.ALL`
    - 부모 엔티티(CartItem)를 저장, 수정, 삭제할 때 자식 엔티티(CartItemOption)에도 동일한 작업이 수행되는 설정입니다.
    - CartItem이 삭제되면 연관된 CartItemOption도 자동으로 함께 삭제됩니다.
- `orphanRemoval = true`
    - 부모 엔티티(CartItem)에서 자식 엔티티(CartItemOption)를 제거했을 때 그 자식이 고아(orphan)가 되면 자동으로 DB에서 삭제됩니다.
    - item.getOptions().remove(option)처럼 컬렉션에서 제거만 해도 실제 DB에서도 해당 옵션이 삭제됩니다.

### 2️⃣ CartRepository에서 CartItemRepository 중심 구조로 책임 분리
- 기존 CartRepository에서 장바구니 관련 모든 로직을 사용했던 방식에서 변경하여 각 엔티티 역할에 맞도록 CartItemRepository를 추가하여 장바구니 항목 관련 로직만 처리할 수 있게 했습니다.

### 3️⃣ restdocs

## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
